### PR TITLE
Fix examples/structured output comparison

### DIFF
--- a/examples/7_structured_output_comparaison.go
+++ b/examples/7_structured_output_comparaison.go
@@ -78,7 +78,7 @@ func main() {
 	debugLog(debugLevel, "Created %d valid configurations", len(configs))
 
 	// Generate JSON schema for ComplexPerson
-	schema, err := gollm.GenerateJSONSchema(&ComplexPerson{})
+	schema, err := gollm.GenerateJSONSchema(ComplexPerson{})
 	if err != nil {
 		log.Fatalf("Failed to generate JSON schema: %v", err)
 	}


### PR DESCRIPTION
Generating the JSON schema from a struct throws a panic if passed a reference instead of a value, specifically when it hits NumFields().  This little fix makes the example work out of the box.

Observed error before fix:

```
Starting structured output comparison...
panic: reflect: NumField of non-struct type *main.ComplexPerson

goroutine 1 [running]:
reflect.(*rtype).NumField(0x120?)
        /opt/homebrew/Cellar/go/1.23.1/libexec/src/reflect/type.go:794 +0x6c
github.com/teilomillet/gollm/internal/llm.getStructProperties({0x1050e8998, 0x10505aba0})
        /Users/azim/go/pkg/mod/github.com/teilomillet/gollm@v0.0.94/internal/llm/validate.go:45 +0x78
github.com/teilomillet/gollm/internal/llm.GenerateJSONSchema({0x10505aba0, 0x140001b1db0})
        /Users/azim/go/pkg/mod/github.com/teilomillet/gollm@v0.0.94/internal/llm/validate.go:30 +0xa0
github.com/teilomillet/gollm.GenerateJSONSchema(...)
        /Users/azim/go/pkg/mod/github.com/teilomillet/gollm@v0.0.94/validation.go:14
main.main()
        /Users/azim/code/shelf/comparison/main.go:82 +0x500
exit status 2
```