### PR TITLE
create mock llm provider

### DIFF
--- a/providers/mock.go
+++ b/providers/mock.go
@@ -1,0 +1,133 @@
+package providers
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/teilomillet/gollm/config"
+	"github.com/teilomillet/gollm/utils"
+)
+
+// MockProvider implements the Provider interface for testing purposes.
+type MockProvider struct {
+	endpoint     string
+	model        string
+	extraHeaders map[string]string
+	options      map[string]interface{}
+	logger       utils.Logger
+	// Mock response configuration
+	responseText  string
+	shouldError   bool
+	errorMsg      string
+	responses     []string // Queue of preset responses
+	currentIndex  int      // Current position in response queue
+	loopResponses bool     // Whether to loop through responses or error when exhausted
+}
+
+// NewMockProvider creates a new mock provider instance for testing.
+func NewMockProvider(endpoint, model string, extraHeaders map[string]string) Provider {
+	if extraHeaders == nil {
+		extraHeaders = make(map[string]string)
+	}
+	return &MockProvider{
+		endpoint:     endpoint,
+		model:        model,
+		extraHeaders: extraHeaders,
+		options:      make(map[string]interface{}),
+		logger:       utils.NewLogger(utils.LogLevelInfo),
+		responseText: "This is a mock response",
+		responses:    make([]string, 0),
+	}
+}
+
+// SetMockResponse configures the mock response text
+func (p *MockProvider) SetMockResponse(response string) {
+	p.responseText = response
+}
+
+// SetMockError configures the mock to return an error
+func (p *MockProvider) SetMockError(shouldError bool, errorMsg string) {
+	p.shouldError = shouldError
+	p.errorMsg = errorMsg
+}
+
+func (p *MockProvider) SetLogger(logger utils.Logger)             { p.logger = logger }
+func (p *MockProvider) Name() string                              { return "mock" }
+func (p *MockProvider) Endpoint() string                          { return p.endpoint }
+func (p *MockProvider) SetOption(key string, value interface{})   { p.options[key] = value }
+func (p *MockProvider) SupportsJSONSchema() bool                  { return true }
+func (p *MockProvider) SetExtraHeaders(headers map[string]string) { p.extraHeaders = headers }
+
+func (p *MockProvider) Headers() map[string]string {
+	headers := map[string]string{
+		"Content-Type": "application/json",
+	}
+	for k, v := range p.extraHeaders {
+		headers[k] = v
+	}
+	return headers
+}
+
+func (p *MockProvider) PrepareRequest(prompt string, options map[string]interface{}) ([]byte, error) {
+	if p.shouldError {
+		return nil, fmt.Errorf(p.errorMsg)
+	}
+
+	requestBody := map[string]interface{}{
+		"model":  p.model,
+		"prompt": prompt,
+	}
+	for k, v := range options {
+		requestBody[k] = v
+	}
+	return json.Marshal(requestBody)
+}
+
+func (p *MockProvider) PrepareRequestWithSchema(prompt string, options map[string]interface{}, schema interface{}) ([]byte, error) {
+	return p.PrepareRequest(prompt, options)
+}
+
+// SetResponses configures a list of responses to be returned in sequence
+func (p *MockProvider) SetResponses(responses []string, loop bool) {
+	p.responses = responses
+	p.currentIndex = 0
+	p.loopResponses = loop
+}
+
+// getNextResponse returns the next response from the queue
+func (p *MockProvider) getNextResponse() (string, error) {
+	if len(p.responses) == 0 {
+		return p.responseText, nil // Fall back to default response
+	}
+
+	if p.currentIndex >= len(p.responses) {
+		if p.loopResponses {
+			p.currentIndex = 0 // Reset to start
+		} else {
+			return "", fmt.Errorf("mock responses exhausted")
+		}
+	}
+
+	response := p.responses[p.currentIndex]
+	p.currentIndex++
+	return response, nil
+}
+
+func (p *MockProvider) ParseResponse(body []byte) (string, error) {
+	if p.shouldError {
+		return "", fmt.Errorf(p.errorMsg)
+	}
+	return p.getNextResponse()
+}
+
+func (p *MockProvider) HandleFunctionCalls(body []byte) ([]byte, error) {
+	return nil, nil
+}
+
+func (p *MockProvider) SetDefaultOptions(config *config.Config) {
+	p.SetOption("temperature", config.Temperature)
+	p.SetOption("max_tokens", config.MaxTokens)
+	if config.Seed != nil {
+		p.SetOption("seed", *config.Seed)
+	}
+}

--- a/providers/mock_test.go
+++ b/providers/mock_test.go
@@ -1,0 +1,148 @@
+package providers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/teilomillet/gollm/config"
+)
+
+func TestMockProvider(t *testing.T) {
+	// Create a new mock provider
+	provider := NewMockProvider("http://mock.api", "mock-model", nil)
+	mockProvider := provider.(*MockProvider)
+
+	// Test basic provider properties
+	assert.Equal(t, "mock", provider.Name())
+	assert.Equal(t, "http://mock.api", provider.Endpoint())
+	assert.True(t, provider.SupportsJSONSchema())
+
+	// Test mock response
+	expectedResponse := "custom mock response"
+	mockProvider.SetMockResponse(expectedResponse)
+
+	response, err := provider.ParseResponse([]byte("{}"))
+	assert.NoError(t, err)
+	assert.Equal(t, expectedResponse, response)
+
+	// Test error handling
+	mockProvider.SetMockError(true, "mock error")
+	_, err = provider.ParseResponse([]byte("{}"))
+	assert.Error(t, err)
+	assert.Equal(t, "mock error", err.Error())
+
+	// Test request preparation
+	mockProvider.SetMockError(false, "")
+	reqBody, err := provider.PrepareRequest("test prompt", map[string]interface{}{
+		"temperature": 0.7,
+	})
+	assert.NoError(t, err)
+	assert.Contains(t, string(reqBody), "test prompt")
+	assert.Contains(t, string(reqBody), "temperature")
+
+	// Test default options
+	cfg := &config.Config{
+		Temperature: 0.8,
+		MaxTokens:   100,
+	}
+	provider.SetDefaultOptions(cfg)
+	assert.Equal(t, 0.8, mockProvider.options["temperature"])
+	assert.Equal(t, 100, mockProvider.options["max_tokens"])
+}
+
+func TestMockProviderResponses(t *testing.T) {
+	provider := NewMockProvider("http://mock.api", "mock-model", nil)
+	mockProvider := provider.(*MockProvider)
+
+	// Test sequential responses
+	responses := []string{
+		"First response",
+		"Second response",
+		"Third response",
+	}
+
+	// Test without looping
+	mockProvider.SetResponses(responses, false)
+
+	// Check each response in sequence
+	for _, expected := range responses {
+		response, err := provider.ParseResponse([]byte("{}"))
+		assert.NoError(t, err)
+		assert.Equal(t, expected, response)
+	}
+
+	// Verify exhaustion error
+	_, err := provider.ParseResponse([]byte("{}"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "exhausted")
+
+	// Test with looping enabled
+	mockProvider.SetResponses(responses, true)
+
+	// Check that responses loop
+	for i := 0; i < len(responses)*2; i++ {
+		response, err := provider.ParseResponse([]byte("{}"))
+		assert.NoError(t, err)
+		assert.Equal(t, responses[i%len(responses)], response)
+	}
+}
+
+func TestMockProviderResponsePatterns(t *testing.T) {
+	provider := NewMockProvider("http://mock.api", "mock-model", nil)
+	mockProvider := provider.(*MockProvider)
+
+	// Test different response patterns
+	testCases := []struct {
+		name      string
+		responses []string
+		loop      bool
+		calls     int
+		expected  []string
+		errorAt   int // -1 for no error expected
+	}{
+		{
+			name:      "Single response",
+			responses: []string{"one"},
+			loop:      true,
+			calls:     3,
+			expected:  []string{"one", "one", "one"},
+			errorAt:   -1,
+		},
+		{
+			name:      "Multiple responses no loop",
+			responses: []string{"first", "second"},
+			loop:      false,
+			calls:     3,
+			expected:  []string{"first", "second"},
+			errorAt:   2,
+		},
+		{
+			name:      "Empty response list",
+			responses: []string{},
+			loop:      false,
+			calls:     2,
+			expected:  []string{"This is a mock response", "This is a mock response"},
+			errorAt:   -1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			mockProvider.SetResponses(tc.responses, tc.loop)
+
+			for i := 0; i < tc.calls; i++ {
+				response, err := provider.ParseResponse([]byte("{}"))
+
+				if tc.errorAt == i {
+					assert.Error(t, err)
+					return
+				}
+
+				assert.NoError(t, err)
+				if i < len(tc.expected) {
+					assert.Equal(t, tc.expected[i], response)
+				}
+			}
+		})
+	}
+}

--- a/providers/provider.go
+++ b/providers/provider.go
@@ -80,6 +80,7 @@ type ProviderRegistry struct {
 //   - "groq": Groq's LLM services
 //   - "ollama": Local LLM deployment
 //   - "mistral": Mistral AI's models
+//   - "mock": Mock provider for testing
 //
 // Example usage:
 //
@@ -100,6 +101,7 @@ func NewProviderRegistry(providerNames ...string) *ProviderRegistry {
 		"groq":      NewGroqProvider,
 		"ollama":    NewOllamaProvider,
 		"mistral":   NewMistralProvider,
+		"mock":      NewMockProvider,
 		// Add other providers here as they are implemented
 	}
 


### PR DESCRIPTION
Have created a Mock provider as a testing endpoint, after I could not get MockProvider in gollm_test.go to work (the current test in main does not work).

Functionality inspired by langchaingo's FakeLLM. 

Tested in mock_test.go which also provides usage examples.