### PR TITLE
wip: adding azureopenai provider

### DIFF
--- a/providers/azureopenai.go
+++ b/providers/azureopenai.go
@@ -1,0 +1,59 @@
+package providers
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/teilomillet/gollm/utils"
+)
+
+type AzureOpenAIProvider struct {
+	Provider     // Embed the OpenAIProvider
+	extraHeaders map[string]string
+	logger       utils.Logger
+	endpoint     string
+	model        string
+	apiKey       string
+	apiVersion   string
+}
+
+func NewAzureOpenAIProvider(apiKey, model string, extraHeaders map[string]string) Provider {
+	openAI := NewOpenAIProvider(apiKey, model, extraHeaders)
+	return &AzureOpenAIProvider{
+		Provider:     openAI,
+		apiKey:       apiKey,
+		extraHeaders: extraHeaders,
+		model:        model,
+	}
+
+}
+func (p *AzureOpenAIProvider) Endpoint() string {
+	endpoint := os.Getenv("AZURE_OPENAI_ENDPOINT")
+	if endpoint == "" {
+		panic("AZURE_OPENAI_ENDPOINT is not set")
+	}
+	apiVersion := os.Getenv("AZURE_OPENAI_API_VERSION")
+	if apiVersion == "" {
+		panic("AZURE_OPENAI_API_VERSION is not set")
+	}
+	url := "%s/openai/deployments/%s/chat/completions?api-version=%s"
+	return fmt.Sprintf(url, endpoint, p.model, apiVersion)
+}
+
+func (p *AzureOpenAIProvider) Headers() map[string]string {
+	headers := map[string]string{
+		"Content-Type": "application/json",
+	}
+	if p.apiKey != "" {
+		headers["api-key"] = p.apiKey
+	}
+	slog.Info("Headers prepared", "headers", headers)
+
+	for key, value := range p.extraHeaders {
+		headers[key] = value
+	}
+
+	//p.logger.Debug("Headers prepared", "headers", headers)
+	return headers
+}

--- a/providers/provider.go
+++ b/providers/provider.go
@@ -106,12 +106,13 @@ func NewProviderRegistry(providerNames ...string) *ProviderRegistry {
 
 	// Register all known providers
 	knownProviders := map[string]ProviderConstructor{
-		"openai":    NewOpenAIProvider,
-		"anthropic": NewAnthropicProvider,
-		"groq":      NewGroqProvider,
-		"ollama":    NewOllamaProvider,
-		"mistral":   NewMistralProvider,
-		"cohere":    NewCohereProvider,
+		"openai":      NewOpenAIProvider,
+		"anthropic":   NewAnthropicProvider,
+		"groq":        NewGroqProvider,
+		"ollama":      NewOllamaProvider,
+		"mistral":     NewMistralProvider,
+		"cohere":      NewCohereProvider,
+		"azureopenai": NewAzureOpenAIProvider,
 		// Add other providers here as they are implemented
 	}
 


### PR DESCRIPTION
Hello,
I'm working on Azure OpenAI provider .
As Azure OpenAI is just another OpenAI implementation, I've just use composition to make it work.
As you can see, I currently use env variable to get Azure OpenAI Endpoint and Azure  OpenAI ApiVersion.
Like ExtraHeaders, I propose to add ExtraConfs to Config struct to handle every provider additional configs.

```go
type Config struct {
 ....
ExtraHeaders          map[string]string
}``