### PR TITLE
Add Google provider using OpenAI-compatible API

### DIFF
--- a/examples/google_openai/main.go
+++ b/examples/google_openai/main.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/teilomillet/gollm"
+)
+
+func main() {
+	// Get API key from environment variable
+	apiKey := os.Getenv("GEMINI_API_KEY")
+	if apiKey == "" {
+		fmt.Println("Error: GEMINI_API_KEY environment variable not set")
+		os.Exit(1)
+	}
+
+	// Choose a Gemini model
+	model := "gemini-2.0-flash"
+
+	// Create a new LLM instance for Gemini
+	llm, err := gollm.NewLLM(
+		gollm.SetProvider("google-openai"),
+		gollm.SetAPIKey(apiKey),
+		gollm.SetModel(model),
+		gollm.SetMaxTokens(200),
+		gollm.SetLogLevel(gollm.LogLevelDebug),
+	)
+	if err != nil {
+		fmt.Printf("Error creating LLM: %v\n", err)
+		os.Exit(1)
+	}
+
+	ctx := context.Background()
+
+	// Basic text generation prompt
+	prompt1 := gollm.NewPrompt("Explain the concept of 'quantum entanglement' in simple terms.")
+	response1, err := llm.Generate(ctx, prompt1)
+	if err != nil {
+		fmt.Printf("Error generating response 1: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println("Gemini Response:")
+	fmt.Println(response1)
+	fmt.Println("---")
+}

--- a/providers/google_openai.go
+++ b/providers/google_openai.go
@@ -1,0 +1,50 @@
+// Package providers implements LLM provider interfaces and implementations.
+package providers
+
+import (
+	"github.com/teilomillet/gollm/config"
+)
+
+// GoogleProvider implements the Provider interface for Google's Gemini API through the
+// OpenAI-compatible endpoint. Accordingly, it inherits from OpenAIProvider
+type GoogleProvider struct {
+	OpenAIProvider
+}
+
+// NewGoogleProvider creates a new Google provider instance.
+// It initializes the provider with the given API key, model, and optional headers.
+//
+// Parameters:
+//   - apiKey: Gemini API key for authentication
+//   - model: The model to use (e.g., "gemini-2.0-flash")
+//   - extraHeaders: Additional HTTP headers for requests
+//
+// Returns:
+//   - A configured Google Provider instance
+func NewGoogleProvider(apiKey, model string, extraHeaders map[string]string) Provider {
+	provider := &GoogleProvider{
+		OpenAIProvider: *NewOpenAIProvider(apiKey, model, extraHeaders).(*OpenAIProvider),
+	}
+
+	return provider
+}
+
+// Name returns "google" as the provider identifier.
+func (p *GoogleProvider) Name() string {
+	return "google-openai"
+}
+
+// Endpoint returns the Gemini API endpoint URL for generating content.
+func (p *GoogleProvider) Endpoint() string {
+	return "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions"
+}
+
+// SetDefaultOptions configures standard options from the global configuration.
+func (p *GoogleProvider) SetDefaultOptions(config *config.Config) {
+	p.SetOption("temperature", config.Temperature)
+	p.SetOption("max_tokens", config.MaxTokens)
+	if config.Seed != nil {
+		p.SetOption("seed", *config.Seed)
+	}
+	p.logger.Debug("Default options set", "temperature", config.Temperature, "max_tokens", config.MaxTokens)
+}

--- a/providers/google_openai.go
+++ b/providers/google_openai.go
@@ -29,7 +29,7 @@ func NewGoogleProvider(apiKey, model string, extraHeaders map[string]string) Pro
 	return provider
 }
 
-// Name returns "google" as the provider identifier.
+ // Name returns "google-openai" as the provider identifier.
 func (p *GoogleProvider) Name() string {
 	return "google-openai"
 }

--- a/providers/provider.go
+++ b/providers/provider.go
@@ -159,6 +159,7 @@ type ProviderRegistry struct {
 //   - "mistral": Mistral AI's models
 //   - "cohere": Cohere's models
 //   - "deepseek": DeepSeek's models
+//   - "google-openai": Google's Gemini models using OpenAI compatible API
 //
 // Example usage:
 //
@@ -175,13 +176,14 @@ func NewProviderRegistry(providerNames ...string) *ProviderRegistry {
 
 	// Register all known providers
 	knownProviders := map[string]ProviderConstructor{
-		"openai":    NewOpenAIProvider,
-		"anthropic": NewAnthropicProvider,
-		"groq":      NewGroqProvider,
-		"ollama":    NewOllamaProvider,
-		"mistral":   NewMistralProvider,
-		"cohere":    NewCohereProvider,
-		"deepseek":  NewDeepSeekProvider,
+		"openai":        NewOpenAIProvider,
+		"anthropic":     NewAnthropicProvider,
+		"groq":          NewGroqProvider,
+		"ollama":        NewOllamaProvider,
+		"mistral":       NewMistralProvider,
+		"cohere":        NewCohereProvider,
+		"deepseek":      NewDeepSeekProvider,
+		"google-openai": NewGoogleProvider,
 		// Add other providers here as they are implemented
 	}
 
@@ -241,6 +243,16 @@ func NewProviderRegistry(providerNames ...string) *ProviderRegistry {
 			Name:              "deepseek",
 			Type:              TypeOpenAI,
 			Endpoint:          "https://api.deepseek.com/chat/completions",
+			AuthHeader:        "Authorization",
+			AuthPrefix:        "Bearer ",
+			RequiredHeaders:   map[string]string{"Content-Type": "application/json"},
+			SupportsSchema:    true,
+			SupportsStreaming: true,
+		},
+		"google-openai": {
+			Name:              "google-openai",
+			Type:              TypeOpenAI,
+			Endpoint:          "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions",
 			AuthHeader:        "Authorization",
 			AuthPrefix:        "Bearer ",
 			RequiredHeaders:   map[string]string{"Content-Type": "application/json"},


### PR DESCRIPTION
Added a Google provider to access Gemini models. For ease of implementation, it uses Google's OpenAI-compatible endpoint.

## Summary by Sourcery

Add support for Google's Gemini models using an OpenAI-compatible API endpoint

New Features:
- Implement a new Google provider that allows accessing Gemini models through an OpenAI-compatible endpoint

Enhancements:
- Extend the provider registry to support Google's Gemini models
- Create a flexible implementation that inherits from the existing OpenAI provider

Documentation:
- Update provider registry documentation to include the new Google provider

Tests:
- Add an example demonstrating how to use the new Google provider with Gemini models