### PR TITLE
An option for Ollama streaming on non-openai compatible endpoints

### DIFF
--- a/llm/llm.go
+++ b/llm/llm.go
@@ -526,7 +526,7 @@ func (l *LLMImpl) SupportsStreaming() bool {
 
 // providerStream implements TokenStream for a specific provider
 type providerStream struct {
-	decoder       *SSEDecoder
+	decoder       StreamDecoder
 	provider      providers.Provider
 	config        *StreamConfig
 	buffer        []byte
@@ -535,8 +535,15 @@ type providerStream struct {
 }
 
 func newProviderStream(reader io.ReadCloser, provider providers.Provider, config *StreamConfig) *providerStream {
+	var decoder StreamDecoder
+	if provider.Name() == "ollama" {
+		decoder = NewNDJSONDecoder(reader)
+	} else {
+		decoder = NewSSEDecoder(reader)
+	}
+
 	return &providerStream{
-		decoder:       NewSSEDecoder(reader),
+		decoder:       decoder,
 		provider:      provider,
 		config:        config,
 		buffer:        make([]byte, 0, 4096),

--- a/llm/stream_test.go
+++ b/llm/stream_test.go
@@ -1,0 +1,115 @@
+package llm
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSSEDecoder(t *testing.T) {
+	sseData := `event: message
+data: Hello
+
+event: message
+data: World
+
+`
+	reader := strings.NewReader(sseData)
+	decoder := NewSSEDecoder(reader)
+
+	// First event
+	if !decoder.Next() {
+		t.Fatal("Expected first event")
+	}
+	event := decoder.Event()
+	if event.Type != "message" {
+		t.Errorf("Expected type 'message', got '%s'", event.Type)
+	}
+	if string(event.Data) != "Hello\n" {
+		t.Errorf("Expected data 'Hello\\n', got '%s'", string(event.Data))
+	}
+
+	// Second event
+	if !decoder.Next() {
+		t.Fatal("Expected second event")
+	}
+	event = decoder.Event()
+	if event.Type != "message" {
+		t.Errorf("Expected type 'message', got '%s'", event.Type)
+	}
+	if string(event.Data) != "World\n" {
+		t.Errorf("Expected data 'World\\n', got '%s'", string(event.Data))
+	}
+
+	// No more events
+	if decoder.Next() {
+		t.Error("Expected no more events")
+	}
+}
+
+func TestNDJSONDecoder(t *testing.T) {
+	ndjsonData := `{"response": "Hello", "done": false}
+{"response": "World", "done": true}
+`
+	reader := strings.NewReader(ndjsonData)
+	decoder := NewNDJSONDecoder(reader)
+
+	// First line
+	if !decoder.Next() {
+		t.Fatal("Expected first line")
+	}
+	event := decoder.Event()
+	if event.Type != "text" {
+		t.Errorf("Expected type 'text', got '%s'", event.Type)
+	}
+	expected := `{"response": "Hello", "done": false}`
+	if string(event.Data) != expected {
+		t.Errorf("Expected data '%s', got '%s'", expected, string(event.Data))
+	}
+
+	// Second line
+	if !decoder.Next() {
+		t.Fatal("Expected second line")
+	}
+	event = decoder.Event()
+	if event.Type != "text" {
+		t.Errorf("Expected type 'text', got '%s'", event.Type)
+	}
+	expected = `{"response": "World", "done": true}`
+	if string(event.Data) != expected {
+		t.Errorf("Expected data '%s', got '%s'", expected, string(event.Data))
+	}
+
+	// No more lines
+	if decoder.Next() {
+		t.Error("Expected no more lines")
+	}
+}
+
+func TestNDJSONDecoderSkipsEmptyLines(t *testing.T) {
+	ndjsonData := `{"response": "Hello", "done": false}
+
+{"response": "World", "done": true}
+`
+	reader := strings.NewReader(ndjsonData)
+	decoder := NewNDJSONDecoder(reader)
+
+	// First line
+	if !decoder.Next() {
+		t.Fatal("Expected first line")
+	}
+	event := decoder.Event()
+	expected := `{"response": "Hello", "done": false}`
+	if string(event.Data) != expected {
+		t.Errorf("Expected data '%s', got '%s'", expected, string(event.Data))
+	}
+
+	// Second line (should skip empty line)
+	if !decoder.Next() {
+		t.Fatal("Expected second line")
+	}
+	event = decoder.Event()
+	expected = `{"response": "World", "done": true}`
+	if string(event.Data) != expected {
+		t.Errorf("Expected data '%s', got '%s'", expected, string(event.Data))
+	}
+}

--- a/providers/ollama.go
+++ b/providers/ollama.go
@@ -287,6 +287,12 @@ func (p *OllamaProvider) ParseStreamResponse(chunk []byte) (string, error) {
 	if err := json.Unmarshal(chunk, &response); err != nil {
 		return "", err
 	}
+
+	// Check if this is the final chunk
+	if response.Done {
+		return response.Response, io.EOF
+	}
+
 	return response.Response, nil
 }
 


### PR DESCRIPTION
By design, Ollama does not return SSE format from the standard /api/generate or /api/chat/completions endpoints when streaming. Instead it returns NDJSON (newline delimited JSON).

Gollm is currently designed to handle ollama streaming via the openai compatible endpoint `/v1/api/generate` (which emits SSE).

Unfortunately, initializing an ollama provider with  the openai compatible ollama endpoint `http://localhost:11434/v1` , causes [gollm to fail checking `/v1/api/tags`](https://github.com/teilomillet/gollm/blob/f2c105bb57284f83c99050b4d56f96e4bd771996/llm/validate.go#L44-L49) because the tags endpoint doesn't exist under the `/v1` namespace. Initializing without that endpoint, using the default, results in streaming responses being ignored because they don’t match the SSE `data:` start.

Therefore, it seems clear to me that no one is using ollama streaming under the current conditions.

We should be careful not to break any current usage (which only makes sense if people are avoiding streaming). I see a few options for solving it. 

1. Add NDJSON parsing for ollama streaming (since it doesn't seem plausible that anyone is currently using ollama streaming)
   Advantage: Doesn't break exiting users.
   Advantage: Adds streaming without requiring changes to anyone's code.
   Downside: Adds NDJSONDecoder which is only used for Ollama.
2. Add a new ollama-openai provider.
   Advantage: Compatible with most of the rest of gollm, since it uses openai pattern
   Downside: [ollama declares this compatibility experimental and notes that it could have breaking changes and provides incomplete feature set](https://github.com/ollama/ollama/blob/main/docs/openai.md)
   Downside: Need to add a whole new provider.

<details>
I guess we would do something like this, which also allows us to add json schema support.

```diff
@@ -239,6 +240,16 @@ func NewProviderRegistry(providerNames ...string) *ProviderRegistry {
                        SupportsSchema:    false,
                        SupportsStreaming: true,
                },
+               "ollama-openai": {
+                       Name:              "ollama-openai",
+                       Type:              TypeOpenAI,
+                       Endpoint:          "http://localhost:11434/v1/api/generate",
+                       AuthHeader:        "", // Ollama doesn't require authentication
+                       AuthPrefix:        "",
+                       RequiredHeaders:   map[string]string{"Content-Type": "application/json"},
+                       SupportsSchema:    true,
+                       SupportsStreaming: true,
+               },
                "deepseek": {
                        Name:              "deepseek",
                        Type:              TypeOpenAI,
```

</details>

I'm a little confused about if there's some reason this isn't working for me. Is it working for others? It seems like there's an xOR between using the stream compatible openai version and passing the `/api/tags` check. If I'm wrong about this, let me know and feel free to close this.

## Summary by Sourcery

Enable streaming support for Ollama by implementing a StreamDecoder abstraction and an NDJSONDecoder, updating the Ollama provider to signal completion, and covering both SSE and NDJSON streams with unit tests.

New Features:
- Add NDJSONDecoder to parse newline-delimited JSON streaming for the Ollama provider
- Emit EOF when Ollama provider signals completion via its done flag

Enhancements:
- Introduce StreamDecoder interface to unify SSE and NDJSON decoders
- Select the appropriate decoder in providerStream based on provider name

Tests:
- Add unit tests for SSEDecoder event parsing
- Add unit tests for NDJSONDecoder, including skipping empty lines

## Summary by Sourcery

Enable streaming support for the Ollama provider by adding an NDJSON decoder, integrating it via a new StreamDecoder interface, and updating the provider to signal completion correctly.

New Features:
- Add NDJSONDecoder to support newline-delimited JSON streaming for the Ollama provider
- Emit EOF on Ollama provider’s done flag to signal completion during streaming

Enhancements:
- Introduce StreamDecoder interface to unify SSE and NDJSON decoding
- Select decoder implementation based on provider name in providerStream

Tests:
- Add unit tests for SSEDecoder event parsing
- Add unit tests for NDJSONDecoder including skipping empty lines