### PR TITLE
fixes missing package in basic usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,47 +99,47 @@ go get github.com/teilomillet/gollm
 package main
 
 import (
-	"context"
-	"fmt"
-	"log"
-	"os"
-	"time"
+    "context"
+    "fmt"
+    "log"
+    "os"
+    "time"
 
-	"github.com/teilomillet/gollm"
+    "github.com/teilomillet/gollm"
 )
 
 func main() {
-	// Load API key from environment variable
-	apiKey := os.Getenv("OPENAI_API_KEY")
-	if apiKey == "" {
-		log.Fatalf("OPENAI_API_KEY environment variable is not set")
-	}
+    // Load API key from environment variable
+    apiKey := os.Getenv("OPENAI_API_KEY")
+    if apiKey == "" {
+        log.Fatalf("OPENAI_API_KEY environment variable is not set")
+    }
 
-	// Create a new LLM instance with custom configuration
-	llm, err := gollm.NewLLM(
-		gollm.SetProvider("openai"),
-		gollm.SetModel("gpt-4o-mini"),
-		gollm.SetAPIKey(apiKey),
-		gollm.SetMaxTokens(200),
-		gollm.SetMaxRetries(3),
-		gollm.SetRetryDelay(time.Second*2),
-		gollm.SetLogLevel(gollm.LogLevelInfo),
-	)
-	if err != nil {
-		log.Fatalf("Failed to create LLM: %v", err)
-	}
+    // Create a new LLM instance with custom configuration
+    llm, err := gollm.NewLLM(
+        gollm.SetProvider("openai"),
+        gollm.SetModel("gpt-4o-mini"),
+        gollm.SetAPIKey(apiKey),
+        gollm.SetMaxTokens(200),
+        gollm.SetMaxRetries(3),
+        gollm.SetRetryDelay(time.Second*2),
+        gollm.SetLogLevel(gollm.LogLevelInfo),
+    )
+    if err != nil {
+        log.Fatalf("Failed to create LLM: %v", err)
+    }
 
-	ctx := context.Background()
+    ctx := context.Background()
 
-	// Create a basic prompt
-	prompt := gollm.NewPrompt("Explain the concept of 'recursion' in programming.")
+    // Create a basic prompt
+    prompt := gollm.NewPrompt("Explain the concept of 'recursion' in programming.")
 
-	// Generate a response
-	response, err := llm.Generate(ctx, prompt)
-	if err != nil {
-		log.Fatalf("Failed to generate text: %v", err)
-	}
-	fmt.Printf("Response:\n%s\n", response)
+    // Generate a response
+    response, err := llm.Generate(ctx, prompt)
+    if err != nil {
+        log.Fatalf("Failed to generate text: %v", err)
+    }
+    fmt.Printf("Response:\n%s\n", response)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -99,46 +99,47 @@ go get github.com/teilomillet/gollm
 package main
 
 import (
-    "context"
-    "fmt"
-    "log"
-    "os"
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
 
-    "github.com/teilomillet/gollm"
+	"github.com/teilomillet/gollm"
 )
 
 func main() {
-    // Load API key from environment variable
-    apiKey := os.Getenv("OPENAI_API_KEY")
-    if apiKey == "" {
-        log.Fatalf("OPENAI_API_KEY environment variable is not set")
-    }
+	// Load API key from environment variable
+	apiKey := os.Getenv("OPENAI_API_KEY")
+	if apiKey == "" {
+		log.Fatalf("OPENAI_API_KEY environment variable is not set")
+	}
 
-    // Create a new LLM instance with custom configuration
-    llm, err := gollm.NewLLM(
-        gollm.SetProvider("openai"),
-        gollm.SetModel("gpt-4o-mini"),
-        gollm.SetAPIKey(apiKey),
-        gollm.SetMaxTokens(200),
-        gollm.SetMaxRetries(3),
-        gollm.SetRetryDelay(time.Second*2),
-        gollm.SetLogLevel(gollm.LogLevelInfo),
-    )
-    if err != nil {
-        log.Fatalf("Failed to create LLM: %v", err)
-    }
+	// Create a new LLM instance with custom configuration
+	llm, err := gollm.NewLLM(
+		gollm.SetProvider("openai"),
+		gollm.SetModel("gpt-4o-mini"),
+		gollm.SetAPIKey(apiKey),
+		gollm.SetMaxTokens(200),
+		gollm.SetMaxRetries(3),
+		gollm.SetRetryDelay(time.Second*2),
+		gollm.SetLogLevel(gollm.LogLevelInfo),
+	)
+	if err != nil {
+		log.Fatalf("Failed to create LLM: %v", err)
+	}
 
-    ctx := context.Background()
+	ctx := context.Background()
 
-    // Create a basic prompt
-    prompt := gollm.NewPrompt("Explain the concept of 'recursion' in programming.")
+	// Create a basic prompt
+	prompt := gollm.NewPrompt("Explain the concept of 'recursion' in programming.")
 
-    // Generate a response
-    response, err := llm.Generate(ctx, prompt)
-    if err != nil {
-        log.Fatalf("Failed to generate text: %v", err)
-    }
-    fmt.Printf("Response:\n%s\n", response)
+	// Generate a response
+	response, err := llm.Generate(ctx, prompt)
+	if err != nil {
+		log.Fatalf("Failed to generate text: %v", err)
+	}
+	fmt.Printf("Response:\n%s\n", response)
 }
 ```
 


### PR DESCRIPTION
this PR adds the missing `time` package in the example under README.md -> QuickStart -> Basic Usage section.

## Summary by Sourcery

Documentation:
- Add missing time package import in the QuickStart basic usage code snippet