### PR TITLE
feat: Add vLLM provider support for local models without API key

### DIFF
--- a/config.go
+++ b/config.go
@@ -79,6 +79,7 @@ var (
 	SetProvider       = config.SetProvider       // Sets the LLM provider (e.g., "openai", "anthropic")
 	SetModel          = config.SetModel          // Sets the model name for the selected provider
 	SetOllamaEndpoint = config.SetOllamaEndpoint // Sets the endpoint URL for Ollama local deployment
+	SetVLLMEndpoint   = config.SetVLLMEndpoint   // Sets the endpoint URL for vLLM local deployment
 	SetAPIKey         = config.SetAPIKey         // Sets the API key for the current provider
 
 	// Generation parameters

--- a/config/config.go
+++ b/config/config.go
@@ -54,6 +54,7 @@ type Config struct {
 	Provider              string            `env:"LLM_PROVIDER" envDefault:"anthropic" validate:"required"`
 	Model                 string            `env:"LLM_MODEL" envDefault:"claude-3-5-haiku-latest" validate:"required"`
 	OllamaEndpoint        string            `env:"OLLAMA_ENDPOINT" envDefault:"http://localhost:11434"`
+	VLLMEndpoint          string            `env:"VLLM_ENDPOINT" envDefault:"http://localhost:8000"`
 	Temperature           float64           `env:"LLM_TEMPERATURE" envDefault:"0.7" validate:"gte=0,lte=1"`
 	MaxTokens             int               `env:"LLM_MAX_TOKENS" envDefault:"100"`
 	TopP                  float64           `env:"LLM_TOP_P" envDefault:"0.9" validate:"gte=0,lte=1"`
@@ -183,6 +184,13 @@ func SetModel(model string) ConfigOption {
 func SetOllamaEndpoint(endpoint string) ConfigOption {
 	return func(c *Config) {
 		c.OllamaEndpoint = endpoint
+	}
+}
+
+// SetVLLMEndpoint sets the vLLM API endpoint.
+func SetVLLMEndpoint(endpoint string) ConfigOption {
+	return func(c *Config) {
+		c.VLLMEndpoint = endpoint
 	}
 }
 

--- a/gollm.go
+++ b/gollm.go
@@ -271,8 +271,8 @@ func NewLLM(opts ...ConfigOption) (LLM, error) {
 		opt(cfg)
 	}
 
-	// For local LLM servers (Ollama, LM Studio), ensure we have a dummy API key
-	if cfg.Provider == "ollama" || cfg.Provider == "lmstudio" {
+	// For local LLM servers (Ollama, LM Studio, vLLM), ensure we have a dummy API key
+	if cfg.Provider == "ollama" || cfg.Provider == "lmstudio" || cfg.Provider == "vllm" {
 		if cfg.APIKeys == nil {
 			cfg.APIKeys = make(map[string]string)
 		}

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -95,9 +95,10 @@ func NewLLM(cfg *config.Config, logger utils.Logger, registry *providers.Provide
 		extraHeaders["anthropic-beta"] = "prompt-caching-2024-07-31"
 	}
 
-	// Check if API key is empty
+	// Check if API key is empty (skip for local providers that don't require auth)
 	apiKey := cfg.APIKeys[cfg.Provider]
-	if apiKey == "" {
+	isLocalProvider := cfg.Provider == "ollama" || cfg.Provider == "lmstudio" || cfg.Provider == "vllm"
+	if apiKey == "" && !isLocalProvider {
 		return nil, NewLLMError(ErrorTypeAuthentication, "empty API key", nil)
 	}
 

--- a/llm/validate.go
+++ b/llm/validate.go
@@ -38,9 +38,12 @@ func validateAPIKey(fl validator.FieldLevel) bool {
 	parent := fl.Parent()
 	provider := parent.FieldByName("Provider").String()
 
-	// For local LLM servers, we don't require an API key
-	// Just check if the endpoint is accessible
+	// For local LLM servers, we don't require an API key.
+	// Just check if the endpoint is accessible (or return true for vLLM).
 	switch provider {
+	case "vllm":
+		// vLLM uses OpenAI-compatible API without authentication
+		return true
 	case "ollama":
 		endpoint := parent.FieldByName("OllamaEndpoint").String()
 		if endpoint == "" {

--- a/providers/cohere.go
+++ b/providers/cohere.go
@@ -20,6 +20,7 @@ var cohereSupportedParams = map[string]bool{
 	"presence_penalty":  true,
 	"k":                 true,
 	"p":                 true,
+	"stream":            true,
 }
 
 // CohereProvider implements the Provider interface for Cohere's API.

--- a/providers/cohere.go
+++ b/providers/cohere.go
@@ -32,18 +32,25 @@ logger       utils.Logger      // Logger instance
 //
 // Returns:
 //   - A configured Cohere Provider instance
+//   - A configured Cohere Provider instance
 func NewCohereProvider(apiKey, model string, extraHeaders map[string]string) Provider {
-if extraHeaders == nil {
-extraHeaders = make(map[string]string)
+	return NewCohereProviderWithURL(apiKey, model, "https://api.cohere.com", extraHeaders)
 }
 
-return &CohereProvider{
-apiKey:       apiKey,
-model:        model,
-extraHeaders: extraHeaders,
-options:      make(map[string]any),
-logger:       utils.NewLogger(utils.LogLevelInfo),
-}
+// NewCohereProviderWithURL creates a new Cohere provider with a custom base URL
+func NewCohereProviderWithURL(apiKey, model, baseURL string, extraHeaders map[string]string) Provider {
+	if extraHeaders == nil {
+		extraHeaders = make(map[string]string)
+	}
+
+	return &CohereProvider{
+		apiKey:       apiKey,
+		baseURL:      baseURL,
+		model:        model,
+		extraHeaders: extraHeaders,
+		options:      make(map[string]any),
+		logger:       utils.NewLogger(utils.LogLevelInfo),
+	}
 }
 
 // SetLogger configures the logger for the Cohere provider.

--- a/providers/cohere.go
+++ b/providers/cohere.go
@@ -155,14 +155,29 @@ requestBody := map[string]any{
 },
 }
 
-// First, add default options
-for k, v := range p.options {
-requestBody[k] = v
+// Cohere v2 API supported parameters
+supportedParams := map[string]bool{
+"temperature":        true,
+"max_tokens":         true,
+"seed":               true,
+"frequency_penalty":  true,
+"presence_penalty":   true,
+"k":                  true,
+"p":                  true,
 }
 
-// Then, add any additional options (which may override defaults)
-for k, v := range options {
+// First, add default options (filter unsupported)
+for k, v := range p.options {
+if supportedParams[k] {
 requestBody[k] = v
+}
+}
+
+// Then, add any additional options (which may override defaults, filter unsupported)
+for k, v := range options {
+if supportedParams[k] {
+requestBody[k] = v
+}
 }
 
 return json.Marshal(requestBody)
@@ -340,14 +355,25 @@ request := map[string]interface{}{
 "messages": cohereMessages,
 }
 
-// Add other options
+// Add other options (filter unsupported parameters)
+// Cohere v2 API supported parameters: temperature, max_tokens, seed, frequency_penalty, presence_penalty, k, p
+supportedParams := map[string]bool{
+"temperature":        true,
+"max_tokens":         true,
+"seed":               true,
+"frequency_penalty":  true,
+"presence_penalty":   true,
+"k":                  true,
+"p":                  true,
+}
+
 for k, v := range p.options {
-if k != "messages" {
+if k != "messages" && supportedParams[k] {
 request[k] = v
 }
 }
 for k, v := range options {
-if k != "messages" && k != "system_prompt" && k != "structured_messages" {
+if k != "messages" && k != "system_prompt" && k != "structured_messages" && supportedParams[k] {
 request[k] = v
 }
 }

--- a/providers/cohere.go
+++ b/providers/cohere.go
@@ -83,9 +83,16 @@ return "cohere"
 }
 
 // Endpoint returns the base URL for the Cohere API.
-// This is "https://api.cohere.com/v2/chat".
+// Uses the configured baseURL and appends the appropriate API version path.
 func (p *CohereProvider) Endpoint() string {
-return "https://api.cohere.com/v2/chat"
+	baseURL := p.baseURL
+	
+	// Remove trailing slash if present
+	if len(baseURL) > 0 && baseURL[len(baseURL)-1] == '/' {
+		baseURL = baseURL[:len(baseURL)-1]
+	}
+	
+	return baseURL + "/v2/chat"
 }
 
 // SupportsJSONSchema indicates that Cohere supports structured output

--- a/providers/cohere.go
+++ b/providers/cohere.go
@@ -15,7 +15,7 @@ import (
 // including chat completion and structured output
 type CohereProvider struct {
 apiKey       string            // API key for authentication
-tbaseURL      string            // Base URL for API endpoint
+	baseURL      string            // Base URL for API endpoint
 model        string            // Model identifier (e.g., "command-r-plus-08-2024", "command-r-plus-04-2024")
 extraHeaders map[string]string // Additional HTTP headers
 options      map[string]any    // Model-specific options
@@ -31,24 +31,18 @@ logger       utils.Logger      // Logger instance
 //   - extraHeaders: Additional HTTP headers for requests
 //
 // Returns:
+//   - A configured Cohere Provider instance
 func NewCohereProvider(apiKey, model string, extraHeaders map[string]string) Provider {
-return NewCohereProviderWithURL(apiKey, model, "https://api.cohere.com", extraHeaders)
-}
-
-// NewCohereProviderWithURL creates a new Cohere provider with a custom base URL
-func NewCohereProviderWithURL(apiKey, model, baseURL string, extraHeaders map[string]string) Provider {
 if extraHeaders == nil {
 extraHeaders = make(map[string]string)
 }
 
 return &CohereProvider{
 apiKey:       apiKey,
-baseURL:      baseURL,
 model:        model,
 extraHeaders: extraHeaders,
 options:      make(map[string]any),
 logger:       utils.NewLogger(utils.LogLevelInfo),
-}
 }
 }
 
@@ -90,17 +84,8 @@ return "cohere"
 
 // Endpoint returns the base URL for the Cohere API.
 // This is "https://api.cohere.com/v2/chat".
-// Endpoint returns the base URL for the Cohere API.
-// Uses the configured baseURL and appends the appropriate API version path.
 func (p *CohereProvider) Endpoint() string {
-baseURL := p.baseURL
-
-// Remove trailing slash if present
-if len(baseURL) > 0 && baseURL[len(baseURL)-1] == '/' {
-baseURL = baseURL[:len(baseURL)-1]
-}
-
-return baseURL + "/v2/chat"
+return "https://api.cohere.com/v2/chat"
 }
 
 // SupportsJSONSchema indicates that Cohere supports structured output

--- a/providers/cohere.go
+++ b/providers/cohere.go
@@ -143,7 +143,15 @@ func (p *CohereProvider) PrepareRequest(prompt string, options map[string]any) (
 requestBody := map[string]any{
 "model": p.model,
 "messages": []map[string]any{
-{"role": "user", "content": prompt},
+{
+"role": "user",
+"content": []map[string]any{
+{
+"type": "text",
+"text": prompt,
+},
+},
+},
 },
 }
 
@@ -316,8 +324,13 @@ cohereMessages := []map[string]interface{}{}
 
 for _, msg := range messages {
 cohereMessages = append(cohereMessages, map[string]interface{}{
-"role":    msg.Role,
-"content": msg.Content,
+"role": msg.Role,
+"content": []map[string]interface{}{
+{
+"type": "text",
+"text": msg.Content,
+},
+},
 })
 }
 

--- a/providers/cohere.go
+++ b/providers/cohere.go
@@ -144,13 +144,8 @@ requestBody := map[string]any{
 "model": p.model,
 "messages": []map[string]any{
 {
-"role": "user",
-"content": []map[string]any{
-{
-"type": "text",
-"text": prompt,
-},
-},
+"role":    "user",
+"content": prompt, // Cohere v2 API accepts string content
 },
 },
 }
@@ -339,13 +334,8 @@ cohereMessages := []map[string]interface{}{}
 
 for _, msg := range messages {
 cohereMessages = append(cohereMessages, map[string]interface{}{
-"role": msg.Role,
-"content": []map[string]interface{}{
-{
-"type": "text",
-"text": msg.Content,
-},
-},
+"role":    msg.Role,
+"content": msg.Content, // Cohere v2 API accepts string content
 })
 }
 
@@ -368,13 +358,21 @@ supportedParams := map[string]bool{
 }
 
 for k, v := range p.options {
-if k != "messages" && supportedParams[k] {
+if k != "messages" {
+if supportedParams[k] {
 request[k] = v
+} else {
+p.logger.Debug("Filtering unsupported parameter from p.options: %s", k)
+}
 }
 }
 for k, v := range options {
-if k != "messages" && k != "system_prompt" && k != "structured_messages" && supportedParams[k] {
+if k != "messages" && k != "system_prompt" && k != "structured_messages" {
+if supportedParams[k] {
 request[k] = v
+} else {
+p.logger.Debug("Filtering unsupported parameter from options: %s", k)
+}
 }
 }
 
@@ -382,13 +380,8 @@ request[k] = v
 if systemPrompt, ok := options["system_prompt"].(string); ok && systemPrompt != "" {
 // Insert system message at the beginning
 systemMessage := map[string]interface{}{
-"role": "system",
-"content": []map[string]interface{}{
-{
-"type": "text",
-"text": systemPrompt,
-},
-},
+"role":    "system",
+"content": systemPrompt, // Cohere v2 API accepts string content
 }
 request["messages"] = append([]map[string]interface{}{systemMessage}, cohereMessages...)
 }

--- a/providers/cohere.go
+++ b/providers/cohere.go
@@ -1,25 +1,25 @@
 package providers
 
 import (
-"encoding/json"
-"fmt"
-"strings"
+	"encoding/json"
+	"fmt"
+	"strings"
 
-"github.com/teilomillet/gollm/config"
-"github.com/teilomillet/gollm/types"
-"github.com/teilomillet/gollm/utils"
+	"github.com/teilomillet/gollm/config"
+	"github.com/teilomillet/gollm/types"
+	"github.com/teilomillet/gollm/utils"
 )
 
 // CohereProvider implements the Provider interface for Cohere's API.
 // It supports Cohere's language models and provides access to their capabilities,
 // including chat completion and structured output
 type CohereProvider struct {
-apiKey       string            // API key for authentication
+	apiKey       string            // API key for authentication
 	baseURL      string            // Base URL for API endpoint
-model        string            // Model identifier (e.g., "command-r-plus-08-2024", "command-r-plus-04-2024")
-extraHeaders map[string]string // Additional HTTP headers
-options      map[string]any    // Model-specific options
-logger       utils.Logger      // Logger instance
+	model        string            // Model identifier (e.g., "command-r-plus-08-2024", "command-r-plus-04-2024")
+	extraHeaders map[string]string // Additional HTTP headers
+	options      map[string]any    // Model-specific options
+	logger       utils.Logger      // Logger instance
 }
 
 // NewCohereProvider creates a new Cohere provider instance.
@@ -31,7 +31,6 @@ logger       utils.Logger      // Logger instance
 //   - extraHeaders: Additional HTTP headers for requests
 //
 // Returns:
-//   - A configured Cohere Provider instance
 //   - A configured Cohere Provider instance
 func NewCohereProvider(apiKey, model string, extraHeaders map[string]string) Provider {
 	return NewCohereProviderWithURL(apiKey, model, "https://api.cohere.com", extraHeaders)
@@ -56,7 +55,7 @@ func NewCohereProviderWithURL(apiKey, model, baseURL string, extraHeaders map[st
 // SetLogger configures the logger for the Cohere provider.
 // This is used for debugging and monitoring API interactions.
 func (p *CohereProvider) SetLogger(logger utils.Logger) {
-p.logger = logger
+	p.logger = logger
 }
 
 // SetOption sets a specific option for the Cohere provider.
@@ -67,45 +66,45 @@ p.logger = logger
 //   - k: Top k most likely tokens are considered
 //   - strict_tools: If set to true, follow tool definition strictly
 func (p *CohereProvider) SetOption(key string, value any) {
-p.options[key] = value
-if p.logger != nil {
-p.logger.Debug("Setting option for Cohere", "key", key, "value", value)
-}
+	p.options[key] = value
+	if p.logger != nil {
+		p.logger.Debug("Setting option for Cohere", "key", key, "value", value)
+	}
 }
 
 // SetDefaultOptions configures standard options from the global configuration.
 // This includes temperature, max tokens, and sampling parameters.
 func (p *CohereProvider) SetDefaultOptions(config *config.Config) {
-p.SetOption("temperature", config.Temperature)
-p.SetOption("max_tokens", config.MaxTokens)
-p.SetOption("stream", false)
-if config.Seed != nil {
-p.SetOption("seed", *config.Seed)
-}
+	p.SetOption("temperature", config.Temperature)
+	p.SetOption("max_tokens", config.MaxTokens)
+	p.SetOption("stream", false)
+	if config.Seed != nil {
+		p.SetOption("seed", *config.Seed)
+	}
 }
 
 // Name returns "cohere" as the provider identifier.
 func (p *CohereProvider) Name() string {
-return "cohere"
+	return "cohere"
 }
 
 // Endpoint returns the base URL for the Cohere API.
 // Uses the configured baseURL and appends the appropriate API version path.
 func (p *CohereProvider) Endpoint() string {
 	baseURL := p.baseURL
-	
+
 	// Remove trailing slash if present
 	if len(baseURL) > 0 && baseURL[len(baseURL)-1] == '/' {
 		baseURL = baseURL[:len(baseURL)-1]
 	}
-	
+
 	return baseURL + "/v2/chat"
 }
 
 // SupportsJSONSchema indicates that Cohere supports structured output
 // through its system prompts and response formatting capabilities.
 func (p *CohereProvider) SupportsJSONSchema() bool {
-return true
+	return true
 }
 
 // Headers returns the required HTTP headers for Cohere API requests.
@@ -114,15 +113,15 @@ return true
 //   - Authorization: Bearer token using the API key
 //   - Any additional headers specified via SetExtraHeaders
 func (p *CohereProvider) Headers() map[string]string {
-headers := map[string]string{
-"Content-Type":  "application/json",
-"Authorization": "bearer " + p.apiKey,
-}
+	headers := map[string]string{
+		"Content-Type":  "application/json",
+		"Authorization": "bearer " + p.apiKey,
+	}
 
-for k, v := range p.extraHeaders {
-headers[k] = v
-}
-return headers
+	for k, v := range p.extraHeaders {
+		headers[k] = v
+	}
+	return headers
 }
 
 // PrepareRequest creates the request body for a Cohere API call.
@@ -140,42 +139,42 @@ return headers
 //   - Serialized JSON request body
 //   - Any error encountered during preparation
 func (p *CohereProvider) PrepareRequest(prompt string, options map[string]any) ([]byte, error) {
-requestBody := map[string]any{
-"model": p.model,
-"messages": []map[string]any{
-{
-"role":    "user",
-"content": prompt, // Cohere v2 API accepts string content
-},
-},
-}
+	requestBody := map[string]any{
+		"model": p.model,
+		"messages": []map[string]any{
+			{
+				"role":    "user",
+				"content": prompt, // Cohere v2 API accepts string content
+			},
+		},
+	}
 
-// Cohere v2 API supported parameters
-supportedParams := map[string]bool{
-"temperature":        true,
-"max_tokens":         true,
-"seed":               true,
-"frequency_penalty":  true,
-"presence_penalty":   true,
-"k":                  true,
-"p":                  true,
-}
+	// Cohere v2 API supported parameters
+	supportedParams := map[string]bool{
+		"temperature":       true,
+		"max_tokens":        true,
+		"seed":              true,
+		"frequency_penalty": true,
+		"presence_penalty":  true,
+		"k":                 true,
+		"p":                 true,
+	}
 
-// First, add default options (filter unsupported)
-for k, v := range p.options {
-if supportedParams[k] {
-requestBody[k] = v
-}
-}
+	// First, add default options (filter unsupported)
+	for k, v := range p.options {
+		if supportedParams[k] {
+			requestBody[k] = v
+		}
+	}
 
-// Then, add any additional options (which may override defaults, filter unsupported)
-for k, v := range options {
-if supportedParams[k] {
-requestBody[k] = v
-}
-}
+	// Then, add any additional options (which may override defaults, filter unsupported)
+	for k, v := range options {
+		if supportedParams[k] {
+			requestBody[k] = v
+		}
+	}
 
-return json.Marshal(requestBody)
+	return json.Marshal(requestBody)
 }
 
 // PrepareRequestWithSchema creates a request that includes structured output formatting.
@@ -190,28 +189,28 @@ return json.Marshal(requestBody)
 //   - Serialized JSON request body
 //   - Any error encountered during preparation
 func (p *CohereProvider) PrepareRequestWithSchema(prompt string, options map[string]any, schema any) ([]byte, error) {
-requestBody := map[string]any{
-"model": p.model,
-"messages": []map[string]any{
-{"role": "user", "content": prompt},
-},
-"response_format": map[string]any{
-"type":        "json_object",
-"json_schema": schema,
-},
-}
+	requestBody := map[string]any{
+		"model": p.model,
+		"messages": []map[string]any{
+			{"role": "user", "content": prompt},
+		},
+		"response_format": map[string]any{
+			"type":        "json_object",
+			"json_schema": schema,
+		},
+	}
 
-// First, add the default options
-for k, v := range p.options {
-requestBody[k] = v
-}
+	// First, add the default options
+	for k, v := range p.options {
+		requestBody[k] = v
+	}
 
-// Then, add any additional options (which may override defaults)
-for k, v := range options {
-requestBody[k] = v
-}
+	// Then, add any additional options (which may override defaults)
+	for k, v := range options {
+		requestBody[k] = v
+	}
 
-return json.Marshal(requestBody)
+	return json.Marshal(requestBody)
 }
 
 // ParseResponse extracts the generated text from the Cohere API response.
@@ -224,178 +223,172 @@ return json.Marshal(requestBody)
 //   - Generated text content
 //   - Any error encountered during parsing
 func (p *CohereProvider) ParseResponse(body []byte) (string, error) {
-var response struct {
-Message struct {
-Role    string `json:"role"`
-Content []struct {
-Type string `json:"type"`
-Text string `json:"text"`
-} `json:"content"`
-ToolCalls []struct {
-ID       string `json:"id"`
-Type     string `json:"type"`
-Function struct {
-Name      string `json:"name"`
-Arguments string `json:"arguments"`
-} `json:"function"`
-} `json:"tool_calls"`
-} `json:"message"`
-}
+	var response struct {
+		Message struct {
+			Role    string `json:"role"`
+			Content []struct {
+				Type string `json:"type"`
+				Text string `json:"text"`
+			} `json:"content"`
+			ToolCalls []struct {
+				ID       string `json:"id"`
+				Type     string `json:"type"`
+				Function struct {
+					Name      string `json:"name"`
+					Arguments string `json:"arguments"`
+				} `json:"function"`
+			} `json:"tool_calls"`
+		} `json:"message"`
+	}
 
-if err := json.Unmarshal(body, &response); err != nil {
-return "", fmt.Errorf("error parsing response: %w", err)
-}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return "", fmt.Errorf("error parsing response: %w", err)
+	}
 
-if len(response.Message.Content) == 0 {
-return "", fmt.Errorf("empty response from API")
-}
+	if len(response.Message.Content) == 0 {
+		return "", fmt.Errorf("empty response from API")
+	}
 
-var finalResponse strings.Builder
+	var finalResponse strings.Builder
 
-for _, content := range response.Message.Content {
-switch content.Type {
-case "text":
-finalResponse.WriteString(content.Text)
-p.logger.Debug("Text content: %s", content.Text)
-}
-}
+	for _, content := range response.Message.Content {
+		switch content.Type {
+		case "text":
+			finalResponse.WriteString(content.Text)
+			p.logger.Debug("Text content: %s", content.Text)
+		}
+	}
 
-for _, toolCall := range response.Message.ToolCalls {
-// Parse arguments as raw JSON to preserve the exact format
-var args interface{}
-if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &args); err != nil {
-return "", fmt.Errorf("error parsing function arguments: %w", err)
-}
+	for _, toolCall := range response.Message.ToolCalls {
+		// Parse arguments as raw JSON to preserve the exact format
+		var args interface{}
+		if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &args); err != nil {
+			return "", fmt.Errorf("error parsing function arguments: %w", err)
+		}
 
-functionCall, err := utils.FormatFunctionCall(toolCall.Function.Name, args)
-if err != nil {
-return "", fmt.Errorf("error formatting function call: %w", err)
-}
-if finalResponse.Len() > 0 {
-finalResponse.WriteString("\n")
-}
-finalResponse.WriteString(functionCall)
-}
+		functionCall, err := utils.FormatFunctionCall(toolCall.Function.Name, args)
+		if err != nil {
+			return "", fmt.Errorf("error formatting function call: %w", err)
+		}
+		if finalResponse.Len() > 0 {
+			finalResponse.WriteString("\n")
+		}
+		finalResponse.WriteString(functionCall)
+	}
 
-p.logger.Debug("Final response: %s", finalResponse.String())
-return finalResponse.String(), nil
+	p.logger.Debug("Final response: %s", finalResponse.String())
+	return finalResponse.String(), nil
 }
 
 // HandleFunctionCalls processes structured output in the response.
 // This supports Cohere's response formatting capabilities.
 func (p *CohereProvider) HandleFunctionCalls(body []byte) ([]byte, error) {
-response := string(body)
-functionCalls, err := utils.ExtractFunctionCalls(response)
-if err != nil {
-return nil, fmt.Errorf("error extracting function calls: %w", err)
-}
+	response := string(body)
+	functionCalls, err := utils.ExtractFunctionCalls(response)
+	if err != nil {
+		return nil, fmt.Errorf("error extracting function calls: %w", err)
+	}
 
-if len(functionCalls) == 0 {
-return nil, nil // No function calls found
-}
+	if len(functionCalls) == 0 {
+		return nil, nil // No function calls found
+	}
 
-return json.Marshal(functionCalls)
+	return json.Marshal(functionCalls)
 }
 
 // SetExtraHeaders configures additional HTTP headers for API requests.
 // This allows for custom headers needed for specific features or requirements.
 func (p *CohereProvider) SetExtraHeaders(extraHeaders map[string]string) {
-p.extraHeaders = extraHeaders
-p.logger.Debug("Extra headers set", "headers", extraHeaders)
+	p.extraHeaders = extraHeaders
+	p.logger.Debug("Extra headers set", "headers", extraHeaders)
 }
 
 // SupportsStreaming returns whether the provider supports streaming responses
 func (p *CohereProvider) SupportsStreaming() bool {
-return true
+	return true
 }
 
 // PrepareStreamRequest prepares a request body for streaming
 func (p *CohereProvider) PrepareStreamRequest(prompt string, options map[string]interface{}) ([]byte, error) {
-options["stream"] = true
-return p.PrepareRequest(prompt, options)
+	options["stream"] = true
+	return p.PrepareRequest(prompt, options)
 }
 
 // ParseStreamResponse parses a single chunk from a streaming response
 func (p *CohereProvider) ParseStreamResponse(chunk []byte) (string, error) {
-var response struct {
-Text string `json:"text"`
-}
-if err := json.Unmarshal(chunk, &response); err != nil {
-return "", err
-}
-return response.Text, nil
+	var response struct {
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(chunk, &response); err != nil {
+		return "", err
+	}
+	return response.Text, nil
 }
 
 // PrepareRequestWithMessages creates a request using structured message objects.
 // This method uses Cohere v2 API format with messages array for conversation history.
 func (p *CohereProvider) PrepareRequestWithMessages(messages []types.MemoryMessage, options map[string]interface{}) ([]byte, error) {
-// Convert messages to Cohere v2 format
-cohereMessages := []map[string]interface{}{}
+	// Convert messages to Cohere v2 format
+	cohereMessages := []map[string]interface{}{}
 
-for _, msg := range messages {
-cohereMessages = append(cohereMessages, map[string]interface{}{
-"role":    msg.Role,
-"content": msg.Content, // Cohere v2 API accepts string content
-})
-}
+	for _, msg := range messages {
+		cohereMessages = append(cohereMessages, map[string]interface{}{
+			"role":    msg.Role,
+			"content": msg.Content, // Cohere v2 API accepts string content
+		})
+	}
 
-// Build request using v2 API format
-request := map[string]interface{}{
-"model":    p.model,
-"messages": cohereMessages,
-}
+	// Build request using v2 API format
+	request := map[string]interface{}{
+		"model":    p.model,
+		"messages": cohereMessages,
+	}
 
-// Add other options (filter unsupported parameters)
-// Cohere v2 API supported parameters: temperature, max_tokens, seed, frequency_penalty, presence_penalty, k, p
-supportedParams := map[string]bool{
-"temperature":        true,
-"max_tokens":         true,
-"seed":               true,
-"frequency_penalty":  true,
-"presence_penalty":   true,
-"k":                  true,
-"p":                  true,
-}
+	// Add other options (filter unsupported parameters)
+	// Cohere v2 API supported parameters: temperature, max_tokens, seed, frequency_penalty, presence_penalty, k, p
+	supportedParams := map[string]bool{
+		"temperature":       true,
+		"max_tokens":        true,
+		"seed":              true,
+		"frequency_penalty": true,
+		"presence_penalty":  true,
+		"k":                 true,
+		"p":                 true,
+	}
 
-for k, v := range p.options {
-if k != "messages" {
-if supportedParams[k] {
-request[k] = v
-} else {
-p.logger.Debug("Filtering unsupported parameter from p.options: %s", k)
-}
-}
-}
-for k, v := range options {
-if k != "messages" && k != "system_prompt" && k != "structured_messages" {
-if supportedParams[k] {
-request[k] = v
-} else {
-p.logger.Debug("Filtering unsupported parameter from options: %s", k)
-}
-}
-}
+	for k, v := range p.options {
+		if k != "messages" {
+			if supportedParams[k] {
+				request[k] = v
+			} else {
+				p.logger.Debug("Filtering unsupported parameter from p.options: %s", k)
+			}
+		}
+	}
+	for k, v := range options {
+		if k != "messages" && k != "system_prompt" && k != "structured_messages" {
+			if supportedParams[k] {
+				request[k] = v
+			} else {
+				p.logger.Debug("Filtering unsupported parameter from options: %s", k)
+			}
+		}
+	}
 
-// Add system prompt if present (as first message with role "system")
-if systemPrompt, ok := options["system_prompt"].(string); ok && systemPrompt != "" {
-// Insert system message at the beginning
-systemMessage := map[string]interface{}{
-"role":    "system",
-"content": systemPrompt, // Cohere v2 API accepts string content
-}
-request["messages"] = append([]map[string]interface{}{systemMessage}, cohereMessages...)
-}
+	// Add system prompt if present (as first message with role "system")
+	if systemPrompt, ok := options["system_prompt"].(string); ok && systemPrompt != "" {
+		// Insert system message at the beginning
+		systemMessage := map[string]interface{}{
+			"role":    "system",
+			"content": systemPrompt, // Cohere v2 API accepts string content
+		}
+		request["messages"] = append([]map[string]interface{}{systemMessage}, cohereMessages...)
+	}
 
-if p.logger != nil {
-p.logger.Debug("Using Cohere v2 messages format", 
-"message_count", len(cohereMessages))
-}
+	if p.logger != nil {
+		p.logger.Debug("Using Cohere v2 messages format",
+			"message_count", len(cohereMessages))
+	}
 
-// Debug: Log the request body
-	requestJSON, _ := json.MarshalIndent(request, "", "  ")
-	p.logger.Info("Cohere API Request Body: %s", string(requestJSON))
-	p.logger.Info("Cohere API Endpoint: %s", p.Endpoint())
-	p.logger.Info("Cohere API Headers: %v", p.Headers())
-	
 	return json.Marshal(request)
 }

--- a/providers/cohere.go
+++ b/providers/cohere.go
@@ -200,14 +200,16 @@ func (p *CohereProvider) PrepareRequestWithSchema(prompt string, options map[str
 		},
 	}
 
-	// First, add the default options
+	// Filter to only Cohere v2 API supported parameters
 	for k, v := range p.options {
-		requestBody[k] = v
+		if cohereSupportedParams[k] {
+			requestBody[k] = v
+		}
 	}
-
-	// Then, add any additional options (which may override defaults)
 	for k, v := range options {
-		requestBody[k] = v
+		if cohereSupportedParams[k] {
+			requestBody[k] = v
+		}
 	}
 
 	return json.Marshal(requestBody)

--- a/providers/cohere.go
+++ b/providers/cohere.go
@@ -356,8 +356,13 @@ request[k] = v
 if systemPrompt, ok := options["system_prompt"].(string); ok && systemPrompt != "" {
 // Insert system message at the beginning
 systemMessage := map[string]interface{}{
-"role":    "system",
-"content": systemPrompt,
+"role": "system",
+"content": []map[string]interface{}{
+{
+"type": "text",
+"text": systemPrompt,
+},
+},
 }
 request["messages"] = append([]map[string]interface{}{systemMessage}, cohereMessages...)
 }

--- a/providers/cohere.go
+++ b/providers/cohere.go
@@ -15,6 +15,7 @@ import (
 // including chat completion and structured output
 type CohereProvider struct {
 apiKey       string            // API key for authentication
+tbaseURL      string            // Base URL for API endpoint
 model        string            // Model identifier (e.g., "command-r-plus-08-2024", "command-r-plus-04-2024")
 extraHeaders map[string]string // Additional HTTP headers
 options      map[string]any    // Model-specific options
@@ -30,18 +31,24 @@ logger       utils.Logger      // Logger instance
 //   - extraHeaders: Additional HTTP headers for requests
 //
 // Returns:
-//   - A configured Cohere Provider instance
 func NewCohereProvider(apiKey, model string, extraHeaders map[string]string) Provider {
+return NewCohereProviderWithURL(apiKey, model, "https://api.cohere.com", extraHeaders)
+}
+
+// NewCohereProviderWithURL creates a new Cohere provider with a custom base URL
+func NewCohereProviderWithURL(apiKey, model, baseURL string, extraHeaders map[string]string) Provider {
 if extraHeaders == nil {
 extraHeaders = make(map[string]string)
 }
 
 return &CohereProvider{
 apiKey:       apiKey,
+baseURL:      baseURL,
 model:        model,
 extraHeaders: extraHeaders,
 options:      make(map[string]any),
 logger:       utils.NewLogger(utils.LogLevelInfo),
+}
 }
 }
 
@@ -83,8 +90,17 @@ return "cohere"
 
 // Endpoint returns the base URL for the Cohere API.
 // This is "https://api.cohere.com/v2/chat".
+// Endpoint returns the base URL for the Cohere API.
+// Uses the configured baseURL and appends the appropriate API version path.
 func (p *CohereProvider) Endpoint() string {
-return "https://api.cohere.com/v2/chat"
+baseURL := p.baseURL
+
+// Remove trailing slash if present
+if len(baseURL) > 0 && baseURL[len(baseURL)-1] == '/' {
+baseURL = baseURL[:len(baseURL)-1]
+}
+
+return baseURL + "/v2/chat"
 }
 
 // SupportsJSONSchema indicates that Cohere supports structured output
@@ -101,7 +117,7 @@ return true
 func (p *CohereProvider) Headers() map[string]string {
 headers := map[string]string{
 "Content-type":  "application/json",
-"Authorization": "Bearer " + p.apiKey,
+"Authorization": "bearer " + p.apiKey,
 }
 
 for k, v := range p.extraHeaders {

--- a/providers/cohere.go
+++ b/providers/cohere.go
@@ -354,5 +354,11 @@ p.logger.Debug("Using Cohere v2 messages format",
 "message_count", len(cohereMessages))
 }
 
-return json.Marshal(request)
+// Debug: Log the request body
+	requestJSON, _ := json.MarshalIndent(request, "", "  ")
+	p.logger.Info("Cohere API Request Body: %s", string(requestJSON))
+	p.logger.Info("Cohere API Endpoint: %s", p.Endpoint())
+	p.logger.Info("Cohere API Headers: %v", p.Headers())
+	
+	return json.Marshal(request)
 }

--- a/providers/cohere.go
+++ b/providers/cohere.go
@@ -1,24 +1,24 @@
 package providers
 
 import (
-	"encoding/json"
-	"fmt"
-	"strings"
+"encoding/json"
+"fmt"
+"strings"
 
-	"github.com/teilomillet/gollm/config"
-	"github.com/teilomillet/gollm/types"
-	"github.com/teilomillet/gollm/utils"
+"github.com/teilomillet/gollm/config"
+"github.com/teilomillet/gollm/types"
+"github.com/teilomillet/gollm/utils"
 )
 
 // CohereProvider implements the Provider interface for Cohere's API.
 // It supports Cohere's language models and provides access to their capabilities,
 // including chat completion and structured output
 type CohereProvider struct {
-	apiKey       string            // API key for authentication
-	model        string            // Model identifier (e.g., "command-r-plus-08-2024", "command-r-plus-04-2024")
-	extraHeaders map[string]string // Additional HTTP headers
-	options      map[string]any    // Model-specific options
-	logger       utils.Logger      // Logger instance
+apiKey       string            // API key for authentication
+model        string            // Model identifier (e.g., "command-r-plus-08-2024", "command-r-plus-04-2024")
+extraHeaders map[string]string // Additional HTTP headers
+options      map[string]any    // Model-specific options
+logger       utils.Logger      // Logger instance
 }
 
 // NewCohereProvider creates a new Cohere provider instance.
@@ -32,23 +32,23 @@ type CohereProvider struct {
 // Returns:
 //   - A configured Cohere Provider instance
 func NewCohereProvider(apiKey, model string, extraHeaders map[string]string) Provider {
-	if extraHeaders == nil {
-		extraHeaders = make(map[string]string)
-	}
+if extraHeaders == nil {
+extraHeaders = make(map[string]string)
+}
 
-	return &CohereProvider{
-		apiKey:       apiKey,
-		model:        model,
-		extraHeaders: extraHeaders,
-		options:      make(map[string]any),
-		logger:       utils.NewLogger(utils.LogLevelInfo),
-	}
+return &CohereProvider{
+apiKey:       apiKey,
+model:        model,
+extraHeaders: extraHeaders,
+options:      make(map[string]any),
+logger:       utils.NewLogger(utils.LogLevelInfo),
+}
 }
 
 // SetLogger configures the logger for the Cohere provider.
 // This is used for debugging and monitoring API interactions.
 func (p *CohereProvider) SetLogger(logger utils.Logger) {
-	p.logger = logger
+p.logger = logger
 }
 
 // SetOption sets a specific option for the Cohere provider.
@@ -59,38 +59,38 @@ func (p *CohereProvider) SetLogger(logger utils.Logger) {
 //   - k: Top k most likely tokens are considered
 //   - strict_tools: If set to true, follow tool definition strictly
 func (p *CohereProvider) SetOption(key string, value any) {
-	p.options[key] = value
-	if p.logger != nil {
-		p.logger.Debug("Setting option for Cohere", "key", key, "value", value)
-	}
+p.options[key] = value
+if p.logger != nil {
+p.logger.Debug("Setting option for Cohere", "key", key, "value", value)
+}
 }
 
 // SetDefaultOptions configures standard options from the global configuration.
 // This includes temperature, max tokens, and sampling parameters.
 func (p *CohereProvider) SetDefaultOptions(config *config.Config) {
-	p.SetOption("temperature", config.Temperature)
-	p.SetOption("max_tokens", config.MaxTokens)
-	p.SetOption("stream", false)
-	if config.Seed != nil {
-		p.SetOption("seed", *config.Seed)
-	}
+p.SetOption("temperature", config.Temperature)
+p.SetOption("max_tokens", config.MaxTokens)
+p.SetOption("stream", false)
+if config.Seed != nil {
+p.SetOption("seed", *config.Seed)
+}
 }
 
 // Name returns "cohere" as the provider identifier.
 func (p *CohereProvider) Name() string {
-	return "cohere"
+return "cohere"
 }
 
 // Endpoint returns the base URL for the Cohere API.
 // This is "https://api.cohere.com/v2/chat".
 func (p *CohereProvider) Endpoint() string {
-	return "https://api.cohere.com/v2/chat"
+return "https://api.cohere.com/v2/chat"
 }
 
 // SupportsJSONSchema indicates that Cohere supports structured output
 // through its system prompts and response formatting capabilities.
 func (p *CohereProvider) SupportsJSONSchema() bool {
-	return true
+return true
 }
 
 // Headers returns the required HTTP headers for Cohere API requests.
@@ -99,15 +99,15 @@ func (p *CohereProvider) SupportsJSONSchema() bool {
 //   - Authorization: Bearer token using the API key
 //   - Any additional headers specified via SetExtraHeaders
 func (p *CohereProvider) Headers() map[string]string {
-	headers := map[string]string{
-		"Content-type":  "application/json",
-		"Authorization": "Bearer " + p.apiKey,
-	}
+headers := map[string]string{
+"Content-type":  "application/json",
+"Authorization": "Bearer " + p.apiKey,
+}
 
-	for k, v := range p.extraHeaders {
-		headers[k] = v
-	}
-	return headers
+for k, v := range p.extraHeaders {
+headers[k] = v
+}
+return headers
 }
 
 // PrepareRequest creates the request body for a Cohere API call.
@@ -125,24 +125,24 @@ func (p *CohereProvider) Headers() map[string]string {
 //   - Serialized JSON request body
 //   - Any error encountered during preparation
 func (p *CohereProvider) PrepareRequest(prompt string, options map[string]any) ([]byte, error) {
-	requestBody := map[string]any{
-		"model": p.model,
-		"messages": []map[string]any{
-			{"role": "user", "content": prompt},
-		},
-	}
+requestBody := map[string]any{
+"model": p.model,
+"messages": []map[string]any{
+{"role": "user", "content": prompt},
+},
+}
 
-	// First, add default options
-	for k, v := range p.options {
-		requestBody[k] = v
-	}
+// First, add default options
+for k, v := range p.options {
+requestBody[k] = v
+}
 
-	// Then, add any additional options (which may override defaults)
-	for k, v := range options {
-		requestBody[k] = v
-	}
+// Then, add any additional options (which may override defaults)
+for k, v := range options {
+requestBody[k] = v
+}
 
-	return json.Marshal(requestBody)
+return json.Marshal(requestBody)
 }
 
 // PrepareRequestWithSchema creates a request that includes structured output formatting.
@@ -157,28 +157,28 @@ func (p *CohereProvider) PrepareRequest(prompt string, options map[string]any) (
 //   - Serialized JSON request body
 //   - Any error encountered during preparation
 func (p *CohereProvider) PrepareRequestWithSchema(prompt string, options map[string]any, schema any) ([]byte, error) {
-	requestBody := map[string]any{
-		"model": p.model,
-		"messages": []map[string]any{
-			{"role": "user", "content": prompt},
-		},
-		"response_format": map[string]any{
-			"type":        "json_object",
-			"json_schema": schema,
-		},
-	}
+requestBody := map[string]any{
+"model": p.model,
+"messages": []map[string]any{
+{"role": "user", "content": prompt},
+},
+"response_format": map[string]any{
+"type":        "json_object",
+"json_schema": schema,
+},
+}
 
-	// First, add the default options
-	for k, v := range p.options {
-		requestBody[k] = v
-	}
+// First, add the default options
+for k, v := range p.options {
+requestBody[k] = v
+}
 
-	// Then, add any additional options (which may override defaults)
-	for k, v := range options {
-		requestBody[k] = v
-	}
+// Then, add any additional options (which may override defaults)
+for k, v := range options {
+requestBody[k] = v
+}
 
-	return json.Marshal(requestBody)
+return json.Marshal(requestBody)
 }
 
 // ParseResponse extracts the generated text from the Cohere API response.
@@ -191,151 +191,153 @@ func (p *CohereProvider) PrepareRequestWithSchema(prompt string, options map[str
 //   - Generated text content
 //   - Any error encountered during parsing
 func (p *CohereProvider) ParseResponse(body []byte) (string, error) {
-	var response struct {
-		Message struct {
-			Role    string `json:"role"`
-			Content []struct {
-				Type string `json:"type"`
-				Text string `json:"text"`
-			} `json:"content"`
-			ToolCalls []struct {
-				ID       string `json:"id"`
-				Type     string `json:"type"`
-				Function struct {
-					Name      string `json:"name"`
-					Arguments string `json:"arguments"`
-				} `json:"function"`
-			} `json:"tool_calls"`
-		} `json:"message"`
-	}
+var response struct {
+Message struct {
+Role    string `json:"role"`
+Content []struct {
+Type string `json:"type"`
+Text string `json:"text"`
+} `json:"content"`
+ToolCalls []struct {
+ID       string `json:"id"`
+Type     string `json:"type"`
+Function struct {
+Name      string `json:"name"`
+Arguments string `json:"arguments"`
+} `json:"function"`
+} `json:"tool_calls"`
+} `json:"message"`
+}
 
-	if err := json.Unmarshal(body, &response); err != nil {
-		return "", fmt.Errorf("error parsing response: %w", err)
-	}
+if err := json.Unmarshal(body, &response); err != nil {
+return "", fmt.Errorf("error parsing response: %w", err)
+}
 
-	if len(response.Message.Content) == 0 {
-		return "", fmt.Errorf("empty response from API")
-	}
+if len(response.Message.Content) == 0 {
+return "", fmt.Errorf("empty response from API")
+}
 
-	var finalResponse strings.Builder
+var finalResponse strings.Builder
 
-	for _, content := range response.Message.Content {
-		switch content.Type {
-		case "text":
-			finalResponse.WriteString(content.Text)
-			p.logger.Debug("Text content: %s", content.Text)
-		}
-	}
+for _, content := range response.Message.Content {
+switch content.Type {
+case "text":
+finalResponse.WriteString(content.Text)
+p.logger.Debug("Text content: %s", content.Text)
+}
+}
 
-	for _, toolCall := range response.Message.ToolCalls {
-		// Parse arguments as raw JSON to preserve the exact format
-		var args interface{}
-		if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &args); err != nil {
-			return "", fmt.Errorf("error parsing function arguments: %w", err)
-		}
+for _, toolCall := range response.Message.ToolCalls {
+// Parse arguments as raw JSON to preserve the exact format
+var args interface{}
+if err := json.Unmarshal([]byte(toolCall.Function.Arguments), &args); err != nil {
+return "", fmt.Errorf("error parsing function arguments: %w", err)
+}
 
-		functionCall, err := utils.FormatFunctionCall(toolCall.Function.Name, args)
-		if err != nil {
-			return "", fmt.Errorf("error formatting function call: %w", err)
-		}
-		if finalResponse.Len() > 0 {
-			finalResponse.WriteString("\n")
-		}
-		finalResponse.WriteString(functionCall)
-	}
+functionCall, err := utils.FormatFunctionCall(toolCall.Function.Name, args)
+if err != nil {
+return "", fmt.Errorf("error formatting function call: %w", err)
+}
+if finalResponse.Len() > 0 {
+finalResponse.WriteString("\n")
+}
+finalResponse.WriteString(functionCall)
+}
 
-	p.logger.Debug("Final response: %s", finalResponse.String())
-	return finalResponse.String(), nil
+p.logger.Debug("Final response: %s", finalResponse.String())
+return finalResponse.String(), nil
 }
 
 // HandleFunctionCalls processes structured output in the response.
 // This supports Cohere's response formatting capabilities.
 func (p *CohereProvider) HandleFunctionCalls(body []byte) ([]byte, error) {
-	response := string(body)
-	functionCalls, err := utils.ExtractFunctionCalls(response)
-	if err != nil {
-		return nil, fmt.Errorf("error extracting function calls: %w", err)
-	}
+response := string(body)
+functionCalls, err := utils.ExtractFunctionCalls(response)
+if err != nil {
+return nil, fmt.Errorf("error extracting function calls: %w", err)
+}
 
-	if len(functionCalls) == 0 {
-		return nil, nil // No function calls found
-	}
+if len(functionCalls) == 0 {
+return nil, nil // No function calls found
+}
 
-	return json.Marshal(functionCalls)
+return json.Marshal(functionCalls)
 }
 
 // SetExtraHeaders configures additional HTTP headers for API requests.
 // This allows for custom headers needed for specific features or requirements.
 func (p *CohereProvider) SetExtraHeaders(extraHeaders map[string]string) {
-	p.extraHeaders = extraHeaders
-	p.logger.Debug("Extra headers set", "headers", extraHeaders)
+p.extraHeaders = extraHeaders
+p.logger.Debug("Extra headers set", "headers", extraHeaders)
 }
 
 // SupportsStreaming returns whether the provider supports streaming responses
 func (p *CohereProvider) SupportsStreaming() bool {
-	return true
+return true
 }
 
 // PrepareStreamRequest prepares a request body for streaming
 func (p *CohereProvider) PrepareStreamRequest(prompt string, options map[string]interface{}) ([]byte, error) {
-	options["stream"] = true
-	return p.PrepareRequest(prompt, options)
+options["stream"] = true
+return p.PrepareRequest(prompt, options)
 }
 
 // ParseStreamResponse parses a single chunk from a streaming response
 func (p *CohereProvider) ParseStreamResponse(chunk []byte) (string, error) {
-	var response struct {
-		Text string `json:"text"`
-	}
-	if err := json.Unmarshal(chunk, &response); err != nil {
-		return "", err
-	}
-	return response.Text, nil
+var response struct {
+Text string `json:"text"`
+}
+if err := json.Unmarshal(chunk, &response); err != nil {
+return "", err
+}
+return response.Text, nil
 }
 
 // PrepareRequestWithMessages creates a request using structured message objects.
+// This method uses Cohere v2 API format with messages array for conversation history.
 func (p *CohereProvider) PrepareRequestWithMessages(messages []types.MemoryMessage, options map[string]interface{}) ([]byte, error) {
-	// Cohere uses a chat history format
-	chatHistory := []map[string]interface{}{}
-	var userMessage string
+// Convert messages to Cohere v2 format
+cohereMessages := []map[string]interface{}{}
 
-	// Process messages and build chat history
-	for i, msg := range messages {
-		if i == len(messages)-1 && msg.Role == "user" {
-			// Last user message goes in the message field
-			userMessage = msg.Content
-		} else {
-			// Previous messages go into chat history
-			chatHistory = append(chatHistory, map[string]interface{}{
-				"role":    msg.Role,
-				"message": msg.Content,
-			})
-		}
-	}
+for _, msg := range messages {
+cohereMessages = append(cohereMessages, map[string]interface{}{
+"role":    msg.Role,
+"content": msg.Content,
+})
+}
 
-	// Build request
-	request := map[string]interface{}{
-		"model":        p.model,
-		"message":      userMessage,
-		"chat_history": chatHistory,
-	}
+// Build request using v2 API format
+request := map[string]interface{}{
+"model":    p.model,
+"messages": cohereMessages,
+}
 
-	// Add other options
-	for k, v := range p.options {
-		if k != "message" && k != "chat_history" {
-			request[k] = v
-		}
-	}
-	for k, v := range options {
-		if k != "message" && k != "chat_history" && k != "system_prompt" && k != "structured_messages" {
-			request[k] = v
-		}
-	}
+// Add other options
+for k, v := range p.options {
+if k != "messages" {
+request[k] = v
+}
+}
+for k, v := range options {
+if k != "messages" && k != "system_prompt" && k != "structured_messages" {
+request[k] = v
+}
+}
 
-	// Add system prompt if present
-	if systemPrompt, ok := options["system_prompt"].(string); ok && systemPrompt != "" {
-		request["preamble"] = systemPrompt
-	}
+// Add system prompt if present (as first message with role "system")
+if systemPrompt, ok := options["system_prompt"].(string); ok && systemPrompt != "" {
+// Insert system message at the beginning
+systemMessage := map[string]interface{}{
+"role":    "system",
+"content": systemPrompt,
+}
+request["messages"] = append([]map[string]interface{}{systemMessage}, cohereMessages...)
+}
 
-	return json.Marshal(request)
+if p.logger != nil {
+p.logger.Debug("Using Cohere v2 messages format", 
+"message_count", len(cohereMessages))
+}
+
+return json.Marshal(request)
 }

--- a/providers/cohere.go
+++ b/providers/cohere.go
@@ -115,7 +115,7 @@ return true
 //   - Any additional headers specified via SetExtraHeaders
 func (p *CohereProvider) Headers() map[string]string {
 headers := map[string]string{
-"Content-type":  "application/json",
+"Content-Type":  "application/json",
 "Authorization": "bearer " + p.apiKey,
 }
 

--- a/providers/cohere_test.go
+++ b/providers/cohere_test.go
@@ -1,0 +1,165 @@
+package providers
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCohereProvider(t *testing.T) {
+	provider := NewCohereProvider("test-api-key", "command-r-plus", nil)
+
+	assert.Equal(t, "cohere", provider.Name())
+	assert.Equal(t, "https://api.cohere.com/v2/chat", provider.Endpoint())
+}
+
+func TestNewCohereProviderWithURL(t *testing.T) {
+	testCases := []struct {
+		name             string
+		baseURL          string
+		expectedEndpoint string
+	}{
+		{
+			name:             "standard base URL",
+			baseURL:          "https://api.cohere.com",
+			expectedEndpoint: "https://api.cohere.com/v2/chat",
+		},
+		{
+			name:             "base URL with trailing slash",
+			baseURL:          "https://api.cohere.com/",
+			expectedEndpoint: "https://api.cohere.com/v2/chat",
+		},
+		{
+			name:             "custom proxy URL",
+			baseURL:          "https://my-proxy.example.com",
+			expectedEndpoint: "https://my-proxy.example.com/v2/chat",
+		},
+		{
+			name:             "custom proxy URL with trailing slash",
+			baseURL:          "https://my-proxy.example.com/",
+			expectedEndpoint: "https://my-proxy.example.com/v2/chat",
+		},
+		{
+			name:             "localhost URL",
+			baseURL:          "http://localhost:8080",
+			expectedEndpoint: "http://localhost:8080/v2/chat",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			provider := NewCohereProviderWithURL("test-api-key", "command-r-plus", tc.baseURL, nil)
+
+			assert.Equal(t, "cohere", provider.Name())
+			assert.Equal(t, tc.expectedEndpoint, provider.Endpoint())
+		})
+	}
+}
+
+func TestCohereHeaders(t *testing.T) {
+	provider := NewCohereProvider("test-api-key", "command-r-plus", nil)
+
+	headers := provider.Headers()
+
+	assert.Equal(t, "application/json", headers["Content-Type"])
+	assert.Equal(t, "Bearer test-api-key", headers["Authorization"])
+}
+
+func TestCohereHeadersWithExtraHeaders(t *testing.T) {
+	extraHeaders := map[string]string{
+		"X-Custom-Header": "custom-value",
+	}
+	provider := NewCohereProvider("test-api-key", "command-r-plus", extraHeaders)
+
+	headers := provider.Headers()
+
+	assert.Equal(t, "application/json", headers["Content-Type"])
+	assert.Equal(t, "Bearer test-api-key", headers["Authorization"])
+	assert.Equal(t, "custom-value", headers["X-Custom-Header"])
+}
+
+func TestCoherePrepareRequestFiltersUnsupportedParams(t *testing.T) {
+	provider := NewCohereProvider("test-api-key", "command-r-plus", nil).(*CohereProvider)
+
+	// Include both supported and unsupported parameters
+	options := map[string]any{
+		"temperature":   0.7,
+		"max_tokens":    100,
+		"top_p":         0.9,  // unsupported by Cohere v2
+		"unsupported":   true, // unsupported
+		"system_prompt": "test",
+	}
+
+	requestBytes, err := provider.PrepareRequest("Hello", options)
+	require.NoError(t, err)
+
+	var request map[string]any
+	err = json.Unmarshal(requestBytes, &request)
+	require.NoError(t, err)
+
+	// Supported params should be present
+	assert.Equal(t, 0.7, request["temperature"])
+	assert.Equal(t, float64(100), request["max_tokens"])
+
+	// Unsupported params should be filtered out
+	_, hasTopP := request["top_p"]
+	assert.False(t, hasTopP, "top_p should be filtered out")
+
+	_, hasUnsupported := request["unsupported"]
+	assert.False(t, hasUnsupported, "unsupported should be filtered out")
+}
+
+func TestCoherePrepareRequestWithSchemaFiltersUnsupportedParams(t *testing.T) {
+	provider := NewCohereProvider("test-api-key", "command-r-plus", nil).(*CohereProvider)
+
+	options := map[string]any{
+		"temperature": 0.7,
+		"top_p":       0.9, // unsupported
+	}
+
+	schema := map[string]any{
+		"type": "object",
+		"properties": map[string]any{
+			"name": map[string]any{"type": "string"},
+		},
+	}
+
+	requestBytes, err := provider.PrepareRequestWithSchema("Hello", options, schema)
+	require.NoError(t, err)
+
+	var request map[string]any
+	err = json.Unmarshal(requestBytes, &request)
+	require.NoError(t, err)
+
+	// Supported params should be present
+	assert.Equal(t, 0.7, request["temperature"])
+
+	// Unsupported params should be filtered out
+	_, hasTopP := request["top_p"]
+	assert.False(t, hasTopP, "top_p should be filtered out")
+
+	// Schema should be included
+	responseFormat, ok := request["response_format"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "json_object", responseFormat["type"])
+}
+
+func TestCoherePrepareStreamRequestIncludesStream(t *testing.T) {
+	provider := NewCohereProvider("test-api-key", "command-r-plus", nil).(*CohereProvider)
+
+	options := map[string]interface{}{
+		"temperature": 0.7,
+	}
+
+	requestBytes, err := provider.PrepareStreamRequest("Hello", options)
+	require.NoError(t, err)
+
+	var request map[string]any
+	err = json.Unmarshal(requestBytes, &request)
+	require.NoError(t, err)
+
+	assert.Equal(t, true, request["stream"])
+	assert.Equal(t, 0.7, request["temperature"])
+}

--- a/providers/provider.go
+++ b/providers/provider.go
@@ -190,6 +190,7 @@ func NewProviderRegistry(providerNames ...string) *ProviderRegistry {
 		"openrouter":    NewOpenRouterProvider,
 		"lambda":        NewLambdaProvider,
 		"bedrock":       NewBedrockProvider,
+		"vllm":          NewVLLMProvider,
 	}
 
 	// Standard provider configurations
@@ -309,6 +310,16 @@ func NewProviderRegistry(providerNames ...string) *ProviderRegistry {
 			Type:              TypeCustom,
 			Endpoint:          "", // Configured dynamically based on region and model
 			AuthHeader:        "", // Uses AWS Signature V4
+			AuthPrefix:        "",
+			RequiredHeaders:   map[string]string{"Content-Type": "application/json"},
+			SupportsSchema:    true,
+			SupportsStreaming: true,
+		},
+		"vllm": {
+			Name:              "vllm",
+			Type:              TypeOpenAI,
+			Endpoint:          "", // Configured by user for local vLLM server
+			AuthHeader:        "", // No authentication required
 			AuthPrefix:        "",
 			RequiredHeaders:   map[string]string{"Content-Type": "application/json"},
 			SupportsSchema:    true,

--- a/providers/vllm.go
+++ b/providers/vllm.go
@@ -85,12 +85,18 @@ func (p *VLLMProvider) Name() string {
 
 // Endpoint returns the vLLM API endpoint URL.
 // It normalizes the endpoint to ensure proper formatting.
+// Accepts: http://host:port, http://host:port/v1, or http://host:port/v1/chat/completions
 func (p *VLLMProvider) Endpoint() string {
 	endpoint := p.endpoint
 
 	// Remove trailing slash if present
 	if len(endpoint) > 0 && endpoint[len(endpoint)-1] == '/' {
 		endpoint = endpoint[:len(endpoint)-1]
+	}
+
+	// If full path already provided, return as-is
+	if strings.HasSuffix(endpoint, "/chat/completions") {
+		return endpoint
 	}
 
 	// Ensure endpoint ends with /v1 if not already present

--- a/providers/vllm.go
+++ b/providers/vllm.go
@@ -6,6 +6,8 @@ import (
 "encoding/json"
 "fmt"
 "io"
+"strings"
+
 
 "github.com/teilomillet/gollm/config"
 "github.com/teilomillet/gollm/types"
@@ -72,8 +74,21 @@ return "vllm"
 }
 
 // Endpoint returns the vLLM API endpoint URL.
+// It normalizes the base URL to ensure proper formatting.
 func (p *VLLMProvider) Endpoint() string {
-return p.baseURL + "/chat/completions"
+baseURL := p.baseURL
+
+// Remove trailing slash if present
+if len(baseURL) > 0 && baseURL[len(baseURL)-1] == '/' {
+baseURL = baseURL[:len(baseURL)-1]
+}
+
+// Ensure base URL ends with /v1 if not already present
+if !strings.HasSuffix(baseURL, "/v1") {
+baseURL = baseURL + "/v1"
+}
+
+return baseURL + "/chat/completions"
 }
 
 // SupportsJSONSchema indicates that vLLM supports JSON schema validation

--- a/providers/vllm.go
+++ b/providers/vllm.go
@@ -2,26 +2,25 @@
 package providers
 
 import (
-"bytes"
-"encoding/json"
-"fmt"
-"io"
-"strings"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
 
-
-"github.com/teilomillet/gollm/config"
-"github.com/teilomillet/gollm/types"
-"github.com/teilomillet/gollm/utils"
+	"github.com/teilomillet/gollm/config"
+	"github.com/teilomillet/gollm/types"
+	"github.com/teilomillet/gollm/utils"
 )
 
 // VLLMProvider implements the Provider interface for vLLM's OpenAI-compatible API.
 // It supports local models served via vLLM without requiring API key authentication.
 type VLLMProvider struct {
-baseURL      string                 // Base URL for vLLM server (e.g., "http://192.168.1.17:8000/v1")
-model        string                 // Model identifier (e.g., "eduMind-6.7b")
-extraHeaders map[string]string      // Additional HTTP headers
-options      map[string]interface{} // Model-specific options
-logger       utils.Logger           // Logger instance
+	baseURL      string                 // Base URL for vLLM server (e.g., "http://192.168.1.17:8000/v1")
+	model        string                 // Model identifier (e.g., "eduMind-6.7b")
+	extraHeaders map[string]string      // Additional HTTP headers
+	options      map[string]interface{} // Model-specific options
+	logger       utils.Logger           // Logger instance
 }
 
 // NewVLLMProvider creates a new vLLM provider instance.
@@ -35,311 +34,311 @@ logger       utils.Logger           // Logger instance
 // Returns:
 //   - A configured vLLM Provider instance
 func NewVLLMProvider(baseURL, model string, extraHeaders map[string]string) Provider {
-if extraHeaders == nil {
-extraHeaders = make(map[string]string)
-}
-return &VLLMProvider{
-baseURL:      baseURL,
-model:        model,
-extraHeaders: extraHeaders,
-options:      make(map[string]interface{}),
-logger:       utils.NewLogger(utils.LogLevelInfo),
-}
+	if extraHeaders == nil {
+		extraHeaders = make(map[string]string)
+	}
+	return &VLLMProvider{
+		baseURL:      baseURL,
+		model:        model,
+		extraHeaders: extraHeaders,
+		options:      make(map[string]interface{}),
+		logger:       utils.NewLogger(utils.LogLevelInfo),
+	}
 }
 
 // SetLogger configures the logger for the vLLM provider.
 func (p *VLLMProvider) SetLogger(logger utils.Logger) {
-p.logger = logger
+	p.logger = logger
 }
 
 // SetOption sets a specific option for the vLLM provider.
 func (p *VLLMProvider) SetOption(key string, value interface{}) {
-p.options[key] = value
-p.logger.Debug("Option set", "key", key, "value", value)
+	p.options[key] = value
+	p.logger.Debug("Option set", "key", key, "value", value)
 }
 
 // SetDefaultOptions configures standard options from the global configuration.
 func (p *VLLMProvider) SetDefaultOptions(config *config.Config) {
-p.SetOption("temperature", config.Temperature)
-p.SetOption("max_tokens", config.MaxTokens)
-if config.Seed != nil {
-p.SetOption("seed", *config.Seed)
-}
-p.logger.Debug("Default options set", "temperature", config.Temperature, "max_tokens", config.MaxTokens)
+	p.SetOption("temperature", config.Temperature)
+	p.SetOption("max_tokens", config.MaxTokens)
+	if config.Seed != nil {
+		p.SetOption("seed", *config.Seed)
+	}
+	p.logger.Debug("Default options set", "temperature", config.Temperature, "max_tokens", config.MaxTokens)
 }
 
 // Name returns "vllm" as the provider identifier.
 func (p *VLLMProvider) Name() string {
-return "vllm"
+	return "vllm"
 }
 
 // Endpoint returns the vLLM API endpoint URL.
 // It normalizes the base URL to ensure proper formatting.
 func (p *VLLMProvider) Endpoint() string {
-baseURL := p.baseURL
+	baseURL := p.baseURL
 
-// Remove trailing slash if present
-if len(baseURL) > 0 && baseURL[len(baseURL)-1] == '/' {
-baseURL = baseURL[:len(baseURL)-1]
-}
+	// Remove trailing slash if present
+	if len(baseURL) > 0 && baseURL[len(baseURL)-1] == '/' {
+		baseURL = baseURL[:len(baseURL)-1]
+	}
 
-// Ensure base URL ends with /v1 if not already present
-if !strings.HasSuffix(baseURL, "/v1") {
-baseURL = baseURL + "/v1"
-}
+	// Ensure base URL ends with /v1 if not already present
+	if !strings.HasSuffix(baseURL, "/v1") {
+		baseURL = baseURL + "/v1"
+	}
 
-return baseURL + "/chat/completions"
+	return baseURL + "/chat/completions"
 }
 
 // SupportsJSONSchema indicates that vLLM supports JSON schema validation
 func (p *VLLMProvider) SupportsJSONSchema() bool {
-return true
+	return true
 }
 
 // Headers returns the required HTTP headers for vLLM API requests.
 // Note: vLLM does NOT require Authorization header for local models
 func (p *VLLMProvider) Headers() map[string]string {
-headers := map[string]string{
-"Content-Type": "application/json",
-}
+	headers := map[string]string{
+		"Content-Type": "application/json",
+	}
 
-for key, value := range p.extraHeaders {
-headers[key] = value
-}
+	for key, value := range p.extraHeaders {
+		headers[key] = value
+	}
 
-p.logger.Debug("Headers prepared", "headers", headers)
-return headers
+	p.logger.Debug("Headers prepared", "headers", headers)
+	return headers
 }
 
 // PrepareRequest creates the request body for a vLLM API call.
 func (p *VLLMProvider) PrepareRequest(prompt string, options map[string]interface{}) ([]byte, error) {
-request := map[string]interface{}{
-"model":    p.model,
-"messages": []map[string]interface{}{},
-}
+	request := map[string]interface{}{
+		"model":    p.model,
+		"messages": []map[string]interface{}{},
+	}
 
-// Handle system prompt
-if systemPrompt, ok := options["system_prompt"].(string); ok && systemPrompt != "" {
-request["messages"] = append(request["messages"].([]map[string]interface{}), map[string]interface{}{
-"role":    "system",
-"content": systemPrompt,
-})
-}
+	// Handle system prompt
+	if systemPrompt, ok := options["system_prompt"].(string); ok && systemPrompt != "" {
+		request["messages"] = append(request["messages"].([]map[string]interface{}), map[string]interface{}{
+			"role":    "system",
+			"content": systemPrompt,
+		})
+	}
 
-// Add user message
-request["messages"] = append(request["messages"].([]map[string]interface{}), map[string]interface{}{
-"role":    "user",
-"content": prompt,
-})
+	// Add user message
+	request["messages"] = append(request["messages"].([]map[string]interface{}), map[string]interface{}{
+		"role":    "user",
+		"content": prompt,
+	})
 
-// Merge options
-for k, v := range p.options {
-if k != "system_prompt" {
-request[k] = v
-}
-}
+	// Merge options
+	for k, v := range p.options {
+		if k != "system_prompt" {
+			request[k] = v
+		}
+	}
 
-for k, v := range options {
-if k != "system_prompt" {
-request[k] = v
-}
-}
+	for k, v := range options {
+		if k != "system_prompt" {
+			request[k] = v
+		}
+	}
 
-return json.Marshal(request)
+	return json.Marshal(request)
 }
 
 // PrepareRequestWithSchema creates a request that includes JSON schema validation.
 func (p *VLLMProvider) PrepareRequestWithSchema(prompt string, options map[string]interface{}, schema interface{}) ([]byte, error) {
-// vLLM supports OpenAI-compatible JSON schema
-var schemaObj interface{}
-switch s := schema.(type) {
-case string:
-if err := json.Unmarshal([]byte(s), &schemaObj); err != nil {
-return nil, fmt.Errorf("failed to unmarshal schema string: %w", err)
-}
-case []byte:
-if err := json.Unmarshal(s, &schemaObj); err != nil {
-return nil, fmt.Errorf("failed to unmarshal schema bytes: %w", err)
-}
-case map[string]interface{}:
-schemaObj = s
-default:
-schemaBytes, err := json.Marshal(schema)
-if err != nil {
-return nil, fmt.Errorf("failed to marshal schema: %w", err)
-}
-if err := json.Unmarshal(schemaBytes, &schemaObj); err != nil {
-return nil, fmt.Errorf("failed to unmarshal schema: %w", err)
-}
-}
+	// vLLM supports OpenAI-compatible JSON schema
+	var schemaObj interface{}
+	switch s := schema.(type) {
+	case string:
+		if err := json.Unmarshal([]byte(s), &schemaObj); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal schema string: %w", err)
+		}
+	case []byte:
+		if err := json.Unmarshal(s, &schemaObj); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal schema bytes: %w", err)
+		}
+	case map[string]interface{}:
+		schemaObj = s
+	default:
+		schemaBytes, err := json.Marshal(schema)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal schema: %w", err)
+		}
+		if err := json.Unmarshal(schemaBytes, &schemaObj); err != nil {
+			return nil, fmt.Errorf("failed to unmarshal schema: %w", err)
+		}
+	}
 
-request := map[string]interface{}{
-"model": p.model,
-"messages": []map[string]interface{}{
-{"role": "user", "content": prompt},
-},
-"response_format": map[string]interface{}{
-"type": "json_object",
-},
-}
+	request := map[string]interface{}{
+		"model": p.model,
+		"messages": []map[string]interface{}{
+			{"role": "user", "content": prompt},
+		},
+		"response_format": map[string]interface{}{
+			"type": "json_object",
+		},
+	}
 
-// Handle system prompt
-if systemPrompt, ok := options["system_prompt"].(string); ok && systemPrompt != "" {
-request["messages"] = append([]map[string]interface{}{
-{"role": "system", "content": systemPrompt},
-}, request["messages"].([]map[string]interface{})...)
-}
+	// Handle system prompt
+	if systemPrompt, ok := options["system_prompt"].(string); ok && systemPrompt != "" {
+		request["messages"] = append([]map[string]interface{}{
+			{"role": "system", "content": systemPrompt},
+		}, request["messages"].([]map[string]interface{})...)
+	}
 
-// Merge options
-for k, v := range p.options {
-if k != "system_prompt" {
-request[k] = v
-}
-}
+	// Merge options
+	for k, v := range p.options {
+		if k != "system_prompt" {
+			request[k] = v
+		}
+	}
 
-for k, v := range options {
-if k != "system_prompt" {
-request[k] = v
-}
-}
+	for k, v := range options {
+		if k != "system_prompt" {
+			request[k] = v
+		}
+	}
 
-return json.Marshal(request)
+	return json.Marshal(request)
 }
 
 // ParseResponse extracts the generated text from the vLLM API response.
 func (p *VLLMProvider) ParseResponse(body []byte) (string, error) {
-var response struct {
-Choices []struct {
-Message struct {
-Content string `json:"content"`
-} `json:"message"`
-} `json:"choices"`
-}
+	var response struct {
+		Choices []struct {
+			Message struct {
+				Content string `json:"content"`
+			} `json:"message"`
+		} `json:"choices"`
+	}
 
-if err := json.Unmarshal(body, &response); err != nil {
-return "", err
-}
+	if err := json.Unmarshal(body, &response); err != nil {
+		return "", err
+	}
 
-if len(response.Choices) == 0 {
-return "", fmt.Errorf("empty response from API")
-}
+	if len(response.Choices) == 0 {
+		return "", fmt.Errorf("empty response from API")
+	}
 
-return response.Choices[0].Message.Content, nil
+	return response.Choices[0].Message.Content, nil
 }
 
 // HandleFunctionCalls processes function calling in the response.
 func (p *VLLMProvider) HandleFunctionCalls(body []byte) ([]byte, error) {
-// vLLM may support function calling depending on the model
-return nil, fmt.Errorf("function calling not implemented for vLLM")
+	// vLLM may support function calling depending on the model
+	return nil, fmt.Errorf("function calling not implemented for vLLM")
 }
 
 // SetExtraHeaders configures additional HTTP headers for API requests.
 func (p *VLLMProvider) SetExtraHeaders(extraHeaders map[string]string) {
-p.extraHeaders = extraHeaders
-p.logger.Debug("Extra headers set", "headers", extraHeaders)
+	p.extraHeaders = extraHeaders
+	p.logger.Debug("Extra headers set", "headers", extraHeaders)
 }
 
 // SupportsStreaming indicates whether streaming is supported
 func (p *VLLMProvider) SupportsStreaming() bool {
-return true
+	return true
 }
 
 // PrepareStreamRequest creates a request body for streaming API calls
 func (p *VLLMProvider) PrepareStreamRequest(prompt string, options map[string]interface{}) ([]byte, error) {
-requestBody := map[string]interface{}{
-"model": p.model,
-"messages": []map[string]string{
-{"role": "user", "content": prompt},
-},
-"stream": true,
-}
+	requestBody := map[string]interface{}{
+		"model": p.model,
+		"messages": []map[string]string{
+			{"role": "user", "content": prompt},
+		},
+		"stream": true,
+	}
 
-// Merge options
-for k, v := range p.options {
-if k != "stream" {
-requestBody[k] = v
-}
-}
+	// Merge options
+	for k, v := range p.options {
+		if k != "stream" {
+			requestBody[k] = v
+		}
+	}
 
-for k, v := range options {
-if k != "stream" {
-requestBody[k] = v
-}
-}
+	for k, v := range options {
+		if k != "stream" {
+			requestBody[k] = v
+		}
+	}
 
-return json.Marshal(requestBody)
+	return json.Marshal(requestBody)
 }
 
 // ParseStreamResponse processes a single chunk from a streaming response
 func (p *VLLMProvider) ParseStreamResponse(chunk []byte) (string, error) {
-if len(bytes.TrimSpace(chunk)) == 0 {
-return "", fmt.Errorf("empty chunk")
-}
+	if len(bytes.TrimSpace(chunk)) == 0 {
+		return "", fmt.Errorf("empty chunk")
+	}
 
-if bytes.Equal(bytes.TrimSpace(chunk), []byte("[DONE]")) {
-return "", io.EOF
-}
+	if bytes.Equal(bytes.TrimSpace(chunk), []byte("[DONE]")) {
+		return "", io.EOF
+	}
 
-var response struct {
-Choices []struct {
-Delta struct {
-Content string `json:"content"`
-} `json:"delta"`
-FinishReason string `json:"finish_reason"`
-} `json:"choices"`
-}
+	var response struct {
+		Choices []struct {
+			Delta struct {
+				Content string `json:"content"`
+			} `json:"delta"`
+			FinishReason string `json:"finish_reason"`
+		} `json:"choices"`
+	}
 
-if err := json.Unmarshal(chunk, &response); err != nil {
-return "", fmt.Errorf("malformed response: %w", err)
-}
+	if err := json.Unmarshal(chunk, &response); err != nil {
+		return "", fmt.Errorf("malformed response: %w", err)
+	}
 
-if len(response.Choices) == 0 {
-return "", fmt.Errorf("no choices in response")
-}
+	if len(response.Choices) == 0 {
+		return "", fmt.Errorf("no choices in response")
+	}
 
-if response.Choices[0].FinishReason != "" {
-return "", io.EOF
-}
+	if response.Choices[0].FinishReason != "" {
+		return "", io.EOF
+	}
 
-return response.Choices[0].Delta.Content, nil
+	return response.Choices[0].Delta.Content, nil
 }
 
 // PrepareRequestWithMessages creates a request body using structured message objects
 func (p *VLLMProvider) PrepareRequestWithMessages(messages []types.MemoryMessage, options map[string]interface{}) ([]byte, error) {
-request := map[string]interface{}{
-"model":    p.model,
-"messages": []map[string]interface{}{},
-}
+	request := map[string]interface{}{
+		"model":    p.model,
+		"messages": []map[string]interface{}{},
+	}
 
-// Handle system prompt
-if systemPrompt, ok := options["system_prompt"].(string); ok && systemPrompt != "" {
-request["messages"] = append(request["messages"].([]map[string]interface{}), map[string]interface{}{
-"role":    "system",
-"content": systemPrompt,
-})
-}
+	// Handle system prompt
+	if systemPrompt, ok := options["system_prompt"].(string); ok && systemPrompt != "" {
+		request["messages"] = append(request["messages"].([]map[string]interface{}), map[string]interface{}{
+			"role":    "system",
+			"content": systemPrompt,
+		})
+	}
 
-// Convert MemoryMessage objects to vLLM messages format
-for _, msg := range messages {
-message := map[string]interface{}{
-"role":    msg.Role,
-"content": msg.Content,
-}
-request["messages"] = append(request["messages"].([]map[string]interface{}), message)
-}
+	// Convert MemoryMessage objects to vLLM messages format
+	for _, msg := range messages {
+		message := map[string]interface{}{
+			"role":    msg.Role,
+			"content": msg.Content,
+		}
+		request["messages"] = append(request["messages"].([]map[string]interface{}), message)
+	}
 
-// Merge options
-for k, v := range p.options {
-if k != "system_prompt" && k != "structured_messages" {
-request[k] = v
-}
-}
+	// Merge options
+	for k, v := range p.options {
+		if k != "system_prompt" && k != "structured_messages" {
+			request[k] = v
+		}
+	}
 
-for k, v := range options {
-if k != "system_prompt" && k != "structured_messages" {
-request[k] = v
-}
-}
+	for k, v := range options {
+		if k != "system_prompt" && k != "structured_messages" {
+			request[k] = v
+		}
+	}
 
-return json.Marshal(request)
+	return json.Marshal(request)
 }

--- a/providers/vllm.go
+++ b/providers/vllm.go
@@ -177,8 +177,14 @@ func (p *VLLMProvider) PrepareRequestWithSchema(prompt string, options map[strin
 		"messages": []map[string]interface{}{
 			{"role": "user", "content": prompt},
 		},
+		// OpenAI-compatible JSON schema format used by vLLM
 		"response_format": map[string]interface{}{
-			"type": "json_object",
+			"type": "json_schema",
+			"json_schema": map[string]interface{}{
+				"name":   "structured_response",
+				"schema": schemaObj,
+				"strict": true,
+			},
 		},
 	}
 

--- a/providers/vllm.go
+++ b/providers/vllm.go
@@ -1,0 +1,330 @@
+// Package providers implements LLM provider interfaces and implementations.
+package providers
+
+import (
+"bytes"
+"encoding/json"
+"fmt"
+"io"
+
+"github.com/teilomillet/gollm/config"
+"github.com/teilomillet/gollm/types"
+"github.com/teilomillet/gollm/utils"
+)
+
+// VLLMProvider implements the Provider interface for vLLM's OpenAI-compatible API.
+// It supports local models served via vLLM without requiring API key authentication.
+type VLLMProvider struct {
+baseURL      string                 // Base URL for vLLM server (e.g., "http://192.168.1.17:8000/v1")
+model        string                 // Model identifier (e.g., "eduMind-6.7b")
+extraHeaders map[string]string      // Additional HTTP headers
+options      map[string]interface{} // Model-specific options
+logger       utils.Logger           // Logger instance
+}
+
+// NewVLLMProvider creates a new vLLM provider instance.
+// It initializes the provider with the given base URL, model, and optional headers.
+//
+// Parameters:
+//   - baseURL: vLLM server base URL (e.g., "http://192.168.1.17:8000/v1")
+//   - model: The model to use (e.g., "eduMind-6.7b")
+//   - extraHeaders: Additional HTTP headers for requests
+//
+// Returns:
+//   - A configured vLLM Provider instance
+func NewVLLMProvider(baseURL, model string, extraHeaders map[string]string) Provider {
+if extraHeaders == nil {
+extraHeaders = make(map[string]string)
+}
+return &VLLMProvider{
+baseURL:      baseURL,
+model:        model,
+extraHeaders: extraHeaders,
+options:      make(map[string]interface{}),
+logger:       utils.NewLogger(utils.LogLevelInfo),
+}
+}
+
+// SetLogger configures the logger for the vLLM provider.
+func (p *VLLMProvider) SetLogger(logger utils.Logger) {
+p.logger = logger
+}
+
+// SetOption sets a specific option for the vLLM provider.
+func (p *VLLMProvider) SetOption(key string, value interface{}) {
+p.options[key] = value
+p.logger.Debug("Option set", "key", key, "value", value)
+}
+
+// SetDefaultOptions configures standard options from the global configuration.
+func (p *VLLMProvider) SetDefaultOptions(config *config.Config) {
+p.SetOption("temperature", config.Temperature)
+p.SetOption("max_tokens", config.MaxTokens)
+if config.Seed != nil {
+p.SetOption("seed", *config.Seed)
+}
+p.logger.Debug("Default options set", "temperature", config.Temperature, "max_tokens", config.MaxTokens)
+}
+
+// Name returns "vllm" as the provider identifier.
+func (p *VLLMProvider) Name() string {
+return "vllm"
+}
+
+// Endpoint returns the vLLM API endpoint URL.
+func (p *VLLMProvider) Endpoint() string {
+return p.baseURL + "/chat/completions"
+}
+
+// SupportsJSONSchema indicates that vLLM supports JSON schema validation
+func (p *VLLMProvider) SupportsJSONSchema() bool {
+return true
+}
+
+// Headers returns the required HTTP headers for vLLM API requests.
+// Note: vLLM does NOT require Authorization header for local models
+func (p *VLLMProvider) Headers() map[string]string {
+headers := map[string]string{
+"Content-Type": "application/json",
+}
+
+for key, value := range p.extraHeaders {
+headers[key] = value
+}
+
+p.logger.Debug("Headers prepared", "headers", headers)
+return headers
+}
+
+// PrepareRequest creates the request body for a vLLM API call.
+func (p *VLLMProvider) PrepareRequest(prompt string, options map[string]interface{}) ([]byte, error) {
+request := map[string]interface{}{
+"model":    p.model,
+"messages": []map[string]interface{}{},
+}
+
+// Handle system prompt
+if systemPrompt, ok := options["system_prompt"].(string); ok && systemPrompt != "" {
+request["messages"] = append(request["messages"].([]map[string]interface{}), map[string]interface{}{
+"role":    "system",
+"content": systemPrompt,
+})
+}
+
+// Add user message
+request["messages"] = append(request["messages"].([]map[string]interface{}), map[string]interface{}{
+"role":    "user",
+"content": prompt,
+})
+
+// Merge options
+for k, v := range p.options {
+if k != "system_prompt" {
+request[k] = v
+}
+}
+
+for k, v := range options {
+if k != "system_prompt" {
+request[k] = v
+}
+}
+
+return json.Marshal(request)
+}
+
+// PrepareRequestWithSchema creates a request that includes JSON schema validation.
+func (p *VLLMProvider) PrepareRequestWithSchema(prompt string, options map[string]interface{}, schema interface{}) ([]byte, error) {
+// vLLM supports OpenAI-compatible JSON schema
+var schemaObj interface{}
+switch s := schema.(type) {
+case string:
+if err := json.Unmarshal([]byte(s), &schemaObj); err != nil {
+return nil, fmt.Errorf("failed to unmarshal schema string: %w", err)
+}
+case []byte:
+if err := json.Unmarshal(s, &schemaObj); err != nil {
+return nil, fmt.Errorf("failed to unmarshal schema bytes: %w", err)
+}
+case map[string]interface{}:
+schemaObj = s
+default:
+schemaBytes, err := json.Marshal(schema)
+if err != nil {
+return nil, fmt.Errorf("failed to marshal schema: %w", err)
+}
+if err := json.Unmarshal(schemaBytes, &schemaObj); err != nil {
+return nil, fmt.Errorf("failed to unmarshal schema: %w", err)
+}
+}
+
+request := map[string]interface{}{
+"model": p.model,
+"messages": []map[string]interface{}{
+{"role": "user", "content": prompt},
+},
+"response_format": map[string]interface{}{
+"type": "json_object",
+},
+}
+
+// Handle system prompt
+if systemPrompt, ok := options["system_prompt"].(string); ok && systemPrompt != "" {
+request["messages"] = append([]map[string]interface{}{
+{"role": "system", "content": systemPrompt},
+}, request["messages"].([]map[string]interface{})...)
+}
+
+// Merge options
+for k, v := range p.options {
+if k != "system_prompt" {
+request[k] = v
+}
+}
+
+for k, v := range options {
+if k != "system_prompt" {
+request[k] = v
+}
+}
+
+return json.Marshal(request)
+}
+
+// ParseResponse extracts the generated text from the vLLM API response.
+func (p *VLLMProvider) ParseResponse(body []byte) (string, error) {
+var response struct {
+Choices []struct {
+Message struct {
+Content string `json:"content"`
+} `json:"message"`
+} `json:"choices"`
+}
+
+if err := json.Unmarshal(body, &response); err != nil {
+return "", err
+}
+
+if len(response.Choices) == 0 {
+return "", fmt.Errorf("empty response from API")
+}
+
+return response.Choices[0].Message.Content, nil
+}
+
+// HandleFunctionCalls processes function calling in the response.
+func (p *VLLMProvider) HandleFunctionCalls(body []byte) ([]byte, error) {
+// vLLM may support function calling depending on the model
+return nil, fmt.Errorf("function calling not implemented for vLLM")
+}
+
+// SetExtraHeaders configures additional HTTP headers for API requests.
+func (p *VLLMProvider) SetExtraHeaders(extraHeaders map[string]string) {
+p.extraHeaders = extraHeaders
+p.logger.Debug("Extra headers set", "headers", extraHeaders)
+}
+
+// SupportsStreaming indicates whether streaming is supported
+func (p *VLLMProvider) SupportsStreaming() bool {
+return true
+}
+
+// PrepareStreamRequest creates a request body for streaming API calls
+func (p *VLLMProvider) PrepareStreamRequest(prompt string, options map[string]interface{}) ([]byte, error) {
+requestBody := map[string]interface{}{
+"model": p.model,
+"messages": []map[string]string{
+{"role": "user", "content": prompt},
+},
+"stream": true,
+}
+
+// Merge options
+for k, v := range p.options {
+if k != "stream" {
+requestBody[k] = v
+}
+}
+
+for k, v := range options {
+if k != "stream" {
+requestBody[k] = v
+}
+}
+
+return json.Marshal(requestBody)
+}
+
+// ParseStreamResponse processes a single chunk from a streaming response
+func (p *VLLMProvider) ParseStreamResponse(chunk []byte) (string, error) {
+if len(bytes.TrimSpace(chunk)) == 0 {
+return "", fmt.Errorf("empty chunk")
+}
+
+if bytes.Equal(bytes.TrimSpace(chunk), []byte("[DONE]")) {
+return "", io.EOF
+}
+
+var response struct {
+Choices []struct {
+Delta struct {
+Content string `json:"content"`
+} `json:"delta"`
+FinishReason string `json:"finish_reason"`
+} `json:"choices"`
+}
+
+if err := json.Unmarshal(chunk, &response); err != nil {
+return "", fmt.Errorf("malformed response: %w", err)
+}
+
+if len(response.Choices) == 0 {
+return "", fmt.Errorf("no choices in response")
+}
+
+if response.Choices[0].FinishReason != "" {
+return "", io.EOF
+}
+
+return response.Choices[0].Delta.Content, nil
+}
+
+// PrepareRequestWithMessages creates a request body using structured message objects
+func (p *VLLMProvider) PrepareRequestWithMessages(messages []types.MemoryMessage, options map[string]interface{}) ([]byte, error) {
+request := map[string]interface{}{
+"model":    p.model,
+"messages": []map[string]interface{}{},
+}
+
+// Handle system prompt
+if systemPrompt, ok := options["system_prompt"].(string); ok && systemPrompt != "" {
+request["messages"] = append(request["messages"].([]map[string]interface{}), map[string]interface{}{
+"role":    "system",
+"content": systemPrompt,
+})
+}
+
+// Convert MemoryMessage objects to vLLM messages format
+for _, msg := range messages {
+message := map[string]interface{}{
+"role":    msg.Role,
+"content": msg.Content,
+}
+request["messages"] = append(request["messages"].([]map[string]interface{}), message)
+}
+
+// Merge options
+for k, v := range p.options {
+if k != "system_prompt" && k != "structured_messages" {
+request[k] = v
+}
+}
+
+for k, v := range options {
+if k != "system_prompt" && k != "structured_messages" {
+request[k] = v
+}
+}
+
+return json.Marshal(request)
+}

--- a/providers/vllm_test.go
+++ b/providers/vllm_test.go
@@ -1,0 +1,203 @@
+package providers
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewVLLMProvider(t *testing.T) {
+	// apiKey parameter is ignored for vLLM (no auth required)
+	provider := NewVLLMProvider("ignored-api-key", "Qwen/Qwen2-7B-Instruct", nil)
+
+	assert.Equal(t, "vllm", provider.Name())
+	assert.True(t, provider.SupportsJSONSchema())
+	assert.True(t, provider.SupportsStreaming())
+}
+
+func TestVLLMEndpoint(t *testing.T) {
+	testCases := []struct {
+		name             string
+		endpoint         string
+		expectedEndpoint string
+	}{
+		{
+			name:             "default endpoint",
+			endpoint:         "http://localhost:8000",
+			expectedEndpoint: "http://localhost:8000/v1/chat/completions",
+		},
+		{
+			name:             "endpoint with trailing slash",
+			endpoint:         "http://localhost:8000/",
+			expectedEndpoint: "http://localhost:8000/v1/chat/completions",
+		},
+		{
+			name:             "endpoint already has /v1",
+			endpoint:         "http://localhost:8000/v1",
+			expectedEndpoint: "http://localhost:8000/v1/chat/completions",
+		},
+		{
+			name:             "endpoint with /v1 and trailing slash",
+			endpoint:         "http://localhost:8000/v1/",
+			expectedEndpoint: "http://localhost:8000/v1/chat/completions",
+		},
+		{
+			name:             "full path already provided",
+			endpoint:         "http://localhost:8000/v1/chat/completions",
+			expectedEndpoint: "http://localhost:8000/v1/chat/completions",
+		},
+		{
+			name:             "custom host and port",
+			endpoint:         "http://192.168.1.100:9000",
+			expectedEndpoint: "http://192.168.1.100:9000/v1/chat/completions",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			provider := NewVLLMProvider("", "test-model", nil).(*VLLMProvider)
+			provider.SetEndpoint(tc.endpoint)
+
+			assert.Equal(t, tc.expectedEndpoint, provider.Endpoint())
+		})
+	}
+}
+
+func TestVLLMDefaultEndpoint(t *testing.T) {
+	provider := NewVLLMProvider("", "test-model", nil)
+
+	// Default endpoint should be localhost:8000
+	assert.Equal(t, "http://localhost:8000/v1/chat/completions", provider.Endpoint())
+}
+
+func TestVLLMHeaders(t *testing.T) {
+	provider := NewVLLMProvider("", "test-model", nil)
+
+	headers := provider.Headers()
+
+	// vLLM doesn't require Authorization header
+	assert.Equal(t, "application/json", headers["Content-Type"])
+	_, hasAuth := headers["Authorization"]
+	assert.False(t, hasAuth, "vLLM should not have Authorization header")
+}
+
+func TestVLLMHeadersWithExtraHeaders(t *testing.T) {
+	extraHeaders := map[string]string{
+		"X-Custom-Header": "custom-value",
+	}
+	provider := NewVLLMProvider("", "test-model", extraHeaders)
+
+	headers := provider.Headers()
+
+	assert.Equal(t, "application/json", headers["Content-Type"])
+	assert.Equal(t, "custom-value", headers["X-Custom-Header"])
+}
+
+func TestVLLMPrepareRequest(t *testing.T) {
+	provider := NewVLLMProvider("", "test-model", nil).(*VLLMProvider)
+
+	options := map[string]interface{}{
+		"temperature":   0.7,
+		"system_prompt": "You are a helpful assistant.",
+	}
+
+	requestBytes, err := provider.PrepareRequest("Hello", options)
+	require.NoError(t, err)
+
+	var request map[string]interface{}
+	err = json.Unmarshal(requestBytes, &request)
+	require.NoError(t, err)
+
+	assert.Equal(t, "test-model", request["model"])
+	assert.Equal(t, 0.7, request["temperature"])
+
+	messages, ok := request["messages"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, messages, 2) // system + user
+
+	// First message should be system
+	systemMsg := messages[0].(map[string]interface{})
+	assert.Equal(t, "system", systemMsg["role"])
+	assert.Equal(t, "You are a helpful assistant.", systemMsg["content"])
+
+	// Second message should be user
+	userMsg := messages[1].(map[string]interface{})
+	assert.Equal(t, "user", userMsg["role"])
+	assert.Equal(t, "Hello", userMsg["content"])
+}
+
+func TestVLLMPrepareRequestWithSchema(t *testing.T) {
+	provider := NewVLLMProvider("", "test-model", nil).(*VLLMProvider)
+
+	schema := map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"name": map[string]interface{}{"type": "string"},
+		},
+	}
+
+	requestBytes, err := provider.PrepareRequestWithSchema("Hello", nil, schema)
+	require.NoError(t, err)
+
+	var request map[string]interface{}
+	err = json.Unmarshal(requestBytes, &request)
+	require.NoError(t, err)
+
+	// Check response_format includes schema
+	responseFormat, ok := request["response_format"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "json_schema", responseFormat["type"])
+
+	jsonSchema, ok := responseFormat["json_schema"].(map[string]interface{})
+	require.True(t, ok)
+	assert.Equal(t, "structured_response", jsonSchema["name"])
+	assert.Equal(t, true, jsonSchema["strict"])
+	assert.NotNil(t, jsonSchema["schema"])
+}
+
+func TestVLLMPrepareStreamRequest(t *testing.T) {
+	provider := NewVLLMProvider("", "test-model", nil).(*VLLMProvider)
+
+	options := map[string]interface{}{
+		"temperature":   0.7,
+		"system_prompt": "You are helpful.",
+	}
+
+	requestBytes, err := provider.PrepareStreamRequest("Hello", options)
+	require.NoError(t, err)
+
+	var request map[string]interface{}
+	err = json.Unmarshal(requestBytes, &request)
+	require.NoError(t, err)
+
+	assert.Equal(t, true, request["stream"])
+	assert.Equal(t, 0.7, request["temperature"])
+
+	messages, ok := request["messages"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, messages, 2) // system + user
+
+	// First message should be system
+	systemMsg := messages[0].(map[string]interface{})
+	assert.Equal(t, "system", systemMsg["role"])
+}
+
+func TestVLLMPrepareStreamRequestWithoutSystemPrompt(t *testing.T) {
+	provider := NewVLLMProvider("", "test-model", nil).(*VLLMProvider)
+
+	requestBytes, err := provider.PrepareStreamRequest("Hello", nil)
+	require.NoError(t, err)
+
+	var request map[string]interface{}
+	err = json.Unmarshal(requestBytes, &request)
+	require.NoError(t, err)
+
+	messages, ok := request["messages"].([]interface{})
+	require.True(t, ok)
+	assert.Len(t, messages, 1) // only user message
+
+	userMsg := messages[0].(map[string]interface{})
+	assert.Equal(t, "user", userMsg["role"])
+}


### PR DESCRIPTION
- Add VLLMProvider implementation in providers/vllm.go
- Support OpenAI-compatible API without authentication
- Enable JSON schema validation for vLLM
- Support streaming responses
- Skip API key validation for vLLM provider in llm/validate.go
- Register vLLM provider in providers/provider.go

This enables using local vLLM models  with gollm without requiring API key authentication, while maintaining all gollm features like prompt templates, chain of thought, and memory.

## Summary by Sourcery

Add full support for local vLLM models by introducing a VLLMProvider implementation that plugs into the existing OpenAI-compatible interface without requiring API key authentication.

New Features:
- Implement VLLMProvider with request preparation, response parsing, JSON schema support, and streaming support for local vLLM servers
- Register vLLM provider in the provider registry and configure its headers, endpoint, and capabilities

Enhancements:
- Skip API key validation for the vLLM provider in the API key validator

## Summary by Sourcery

Add a vLLM provider for local OpenAI-compatible models and update existing providers and validation to support this configuration.

New Features:
- Introduce a VLLMProvider implementation for local vLLM servers with OpenAI-compatible chat, JSON schema, and streaming support.
- Register the vLLM provider in the provider registry with appropriate capabilities and no-auth configuration.

Enhancements:
- Allow the Cohere provider to use a configurable base URL and align its API usage with the v2 chat/messages format while filtering unsupported parameters.
- Adjust API key validation to treat vLLM as a local provider that does not require an API key.