### PR TITLE
fix(assess): use correct test context for Skip calls

### DIFF
--- a/assess/assess.go
+++ b/assess/assess.go
@@ -113,12 +113,21 @@ func (tr *TestRunner) WithProvider(name, model string) *TestRunner {
 	return tr
 }
 
+// getProviderAPIKeyEnv returns the environment variable name for a provider's API key.
+func getProviderAPIKeyEnv(providerName string) string {
+	return fmt.Sprintf("%s_API_KEY", strings.ToUpper(providerName))
+}
+
+// getProviderAPIKey returns the API key for a provider from environment variables.
+func getProviderAPIKey(providerName string) string {
+	return os.Getenv(getProviderAPIKeyEnv(providerName))
+}
+
 // HasAvailableProviders checks if any configured provider has an API key set.
 // Use this to skip tests early when no providers are available.
 func (tr *TestRunner) HasAvailableProviders() bool {
 	for _, provider := range tr.providers {
-		apiKeyEnv := fmt.Sprintf("%s_API_KEY", strings.ToUpper(provider.Name))
-		if os.Getenv(apiKeyEnv) != "" {
+		if getProviderAPIKey(provider.Name) != "" {
 			return true
 		}
 	}
@@ -239,11 +248,10 @@ func (tr *TestRunner) RunBatch(ctx context.Context) {
 	// Filter providers with available API keys
 	var availableProviders []TestProvider
 	for _, provider := range tr.providers {
-		apiKeyEnv := fmt.Sprintf("%s_API_KEY", strings.ToUpper(provider.Name))
-		if os.Getenv(apiKeyEnv) != "" {
+		if getProviderAPIKey(provider.Name) != "" {
 			availableProviders = append(availableProviders, provider)
 		} else {
-			tr.t.Logf("Skipping provider %s: %s environment variable not set", provider.Name, apiKeyEnv)
+			tr.t.Logf("Skipping provider %s: %s environment variable not set", provider.Name, getProviderAPIKeyEnv(provider.Name))
 		}
 	}
 

--- a/assess/assess.go
+++ b/assess/assess.go
@@ -228,10 +228,14 @@ func (tr *TestRunner) printErrorSummary() {
 	}
 
 	tr.t.Log("\n=== Performance Summary ===")
-	for provider, latency := range tr.batchMetrics.BatchTiming.ProviderLatency {
-		tr.t.Logf("Provider %s - Average Response Time: %v", provider, latency)
+	if tr.batchMetrics != nil {
+		for provider, latency := range tr.batchMetrics.BatchTiming.ProviderLatency {
+			tr.t.Logf("Provider %s - Average Response Time: %v", provider, latency)
+		}
+		tr.t.Logf("Total Execution Time: %v", tr.batchMetrics.BatchTiming.TotalDuration)
+	} else {
+		tr.t.Log("No performance metrics available")
 	}
-	tr.t.Logf("Total Execution Time: %v", tr.batchMetrics.BatchTiming.TotalDuration)
 	tr.t.Log("==================")
 }
 

--- a/assess/assess.go
+++ b/assess/assess.go
@@ -271,6 +271,11 @@ func (tr *TestRunner) RunBatch(ctx context.Context) {
 		return
 	}
 
+	if len(tr.cases) == 0 {
+		tr.t.Log("No test cases configured - skipping batch execution")
+		return
+	}
+
 	ctx, cancel := context.WithTimeout(ctx, tr.batchCfg.BatchTimeout)
 	defer cancel()
 
@@ -663,6 +668,11 @@ func (tr *TestRunner) Run(ctx context.Context) {
 
 	if len(availableProviders) == 0 {
 		tr.t.Log("No providers available: missing API keys - skipping test execution")
+		return
+	}
+
+	if len(tr.cases) == 0 {
+		tr.t.Log("No test cases configured - skipping test execution")
 		return
 	}
 

--- a/assess/assess.go
+++ b/assess/assess.go
@@ -327,7 +327,6 @@ func (tr *TestRunner) RunBatch(ctx context.Context) {
 				if tr.batchCfg.RateLimit != nil {
 					if err := tr.batchCfg.RateLimit.Wait(ctx); err != nil {
 						rateLimitErr := fmt.Errorf("rate limit wait failed: %w", err)
-						tr.recordError(p.Name, rateLimitErr)
 						tr.t.Logf("Rate limit wait error for provider %s: %v", p.Name, err)
 
 						// Send failure result and clean up
@@ -348,7 +347,6 @@ func (tr *TestRunner) RunBatch(ctx context.Context) {
 				// when concurrent goroutines call SetOption on the same client
 				client, err := tr.setupClient(p)
 				if err != nil {
-					tr.recordError(p.Name, err)
 					tr.t.Logf("Client setup error for provider %s: %v", p.Name, err)
 
 					// Send failure result and clean up

--- a/assess/assess.go
+++ b/assess/assess.go
@@ -229,6 +229,12 @@ func (tr *TestRunner) RunBatch(ctx context.Context) {
 			BatchTimeout: 10 * time.Minute,
 		}
 	}
+	if tr.batchMetrics == nil {
+		tr.batchMetrics = &BatchMetrics{
+			Errors: make(map[string][]error),
+		}
+		tr.batchMetrics.BatchTiming.ProviderLatency = make(map[string]time.Duration)
+	}
 
 	// Filter providers with available API keys
 	var availableProviders []TestProvider

--- a/assess/assess.go
+++ b/assess/assess.go
@@ -296,8 +296,7 @@ func (tr *TestRunner) RunBatch(ctx context.Context) {
 	results := make(chan testResult, len(availableProviders)*len(tr.cases))
 
 	for _, provider := range availableProviders {
-		client := tr.setupClient(tr.t, provider)
-		tr.t.Logf("Initialized client for provider: %s", provider.Name)
+		tr.t.Logf("Starting test cases for provider: %s", provider.Name)
 
 		for _, tc := range tr.cases {
 			wg.Add(1)
@@ -322,6 +321,10 @@ func (tr *TestRunner) RunBatch(ctx context.Context) {
 						tr.t.Logf("Rate limit wait error for provider %s: %v", p.Name, err)
 					}
 				}
+
+				// Create a new client for each test case to avoid race conditions
+				// when concurrent goroutines call SetOption on the same client
+				client := tr.setupClient(tr.t, p)
 
 				// Run the test case
 				start := time.Now()

--- a/assess/integration_test.go
+++ b/assess/integration_test.go
@@ -154,6 +154,10 @@ func TestBatchIntegration(t *testing.T) {
 			BatchTimeout: 2 * time.Minute,
 		})
 
+	if !test.HasAvailableProviders() {
+		t.Skip("No providers available: missing API keys")
+	}
+
 	// Test cases with different validation requirements
 	testCases := []struct {
 		name      string

--- a/assess/integration_test.go
+++ b/assess/integration_test.go
@@ -30,6 +30,10 @@ func TestProviderIntegration(t *testing.T) {
 			BatchTimeout: 5 * time.Minute,
 		})
 
+	if !test.HasAvailableProviders() {
+		t.Skip("No providers available: missing API keys")
+	}
+
 	// System prompt for consistent context
 	systemPrompt := `You are an AI assistant participating in a technical discussion about software development, 
 	focusing on topics like system design, performance optimization, and best practices. 
@@ -72,6 +76,10 @@ func TestJSONValidation(t *testing.T) {
 			MaxParallel:  2,
 			BatchTimeout: 5 * time.Minute,
 		})
+
+	if !test.HasAvailableProviders() {
+		t.Skip("No providers available: missing API keys")
+	}
 
 	// Generate schema from struct
 	schema, err := gollm.GenerateJSONSchema(SOLIDResponse{})
@@ -240,6 +248,10 @@ func TestBatchCrossProvider(t *testing.T) {
 			MaxParallel:  2,
 			BatchTimeout: 2 * time.Minute,
 		})
+
+	if !test.HasAvailableProviders() {
+		t.Skip("No providers available: missing API keys")
+	}
 
 	// System prompt to ensure consistent output format
 	systemPrompt := `You are a helpful assistant. Always provide your answers in a clear, concise format.

--- a/llm/memory.go
+++ b/llm/memory.go
@@ -394,10 +394,17 @@ func (l *LLMWithMemory) Generate(ctx context.Context, prompt *Prompt, opts ...Ge
 
 		// Create a new Prompt with the full memory context
 		memoryPrompt := &Prompt{
-			SystemPrompt: prompt.SystemPrompt,
-			Tools:        prompt.Tools,
-			ToolChoice:   prompt.ToolChoice,
-			Input:        fullPrompt,
+			Input:           fullPrompt,
+			Output:          prompt.Output,
+			Directives:      prompt.Directives,
+			Context:         prompt.Context,
+			MaxLength:       prompt.MaxLength,
+			Examples:        prompt.Examples,
+			SystemPrompt:    prompt.SystemPrompt,
+			SystemCacheType: prompt.SystemCacheType,
+			Tools:           prompt.Tools,
+			ToolChoice:      prompt.ToolChoice,
+			// Messages intentionally omitted - using flattened prompt in Input
 		}
 
 		response, err = l.LLM.Generate(ctx, memoryPrompt, opts...)
@@ -488,10 +495,17 @@ func (l *LLMWithMemory) GenerateWithSchema(ctx context.Context, prompt *Prompt, 
 		fullPrompt := l.memory.GetPrompt()
 
 		memoryPrompt := &Prompt{
-			SystemPrompt: prompt.SystemPrompt,
-			Tools:        prompt.Tools,
-			ToolChoice:   prompt.ToolChoice,
-			Input:        fullPrompt,
+			Input:           fullPrompt,
+			Output:          prompt.Output,
+			Directives:      prompt.Directives,
+			Context:         prompt.Context,
+			MaxLength:       prompt.MaxLength,
+			Examples:        prompt.Examples,
+			SystemPrompt:    prompt.SystemPrompt,
+			SystemCacheType: prompt.SystemCacheType,
+			Tools:           prompt.Tools,
+			ToolChoice:      prompt.ToolChoice,
+			// Messages intentionally omitted - using flattened prompt in Input
 		}
 
 		response, err = l.LLM.GenerateWithSchema(ctx, memoryPrompt, schema, opts...)

--- a/llm/memory.go
+++ b/llm/memory.go
@@ -360,10 +360,17 @@ func (l *LLMWithMemory) Generate(ctx context.Context, prompt *Prompt, opts ...Ge
 		// Make a copy of the original prompt with empty input
 		// (since content will be in structured messages)
 		emptyPrompt := &Prompt{
-			SystemPrompt: prompt.SystemPrompt,
-			Tools:        prompt.Tools,
-			ToolChoice:   prompt.ToolChoice,
-			Input:        "", // Empty as content is in messages
+			Input:           "", // Empty as content is in messages
+			Output:          prompt.Output,
+			Directives:      prompt.Directives,
+			Context:         prompt.Context,
+			MaxLength:       prompt.MaxLength,
+			Examples:        prompt.Examples,
+			SystemPrompt:    prompt.SystemPrompt,
+			SystemCacheType: prompt.SystemCacheType,
+			Tools:           prompt.Tools,
+			ToolChoice:      prompt.ToolChoice,
+			// Messages intentionally omitted - using structured_messages option instead
 		}
 
 		// This is an intentional no-op GenerateOption. The structured messages are
@@ -455,10 +462,17 @@ func (l *LLMWithMemory) GenerateWithSchema(ctx context.Context, prompt *Prompt, 
 		// Make a copy of the original prompt with empty input
 		// (since content will be in structured messages)
 		emptyPrompt := &Prompt{
-			SystemPrompt: prompt.SystemPrompt,
-			Tools:        prompt.Tools,
-			ToolChoice:   prompt.ToolChoice,
-			Input:        "", // Empty as content is in messages
+			Input:           "", // Empty as content is in messages
+			Output:          prompt.Output,
+			Directives:      prompt.Directives,
+			Context:         prompt.Context,
+			MaxLength:       prompt.MaxLength,
+			Examples:        prompt.Examples,
+			SystemPrompt:    prompt.SystemPrompt,
+			SystemCacheType: prompt.SystemCacheType,
+			Tools:           prompt.Tools,
+			ToolChoice:      prompt.ToolChoice,
+			// Messages intentionally omitted - using structured_messages option instead
 		}
 
 		// Set structured messages option


### PR DESCRIPTION
## Problem

Tests in the `assess` package were failing with:
```
test executed panic(nil) or runtime.Goexit: subtest may have called FailNow on a parent test
```

This happened because `setupClient()` called `t.Skip()` on the parent test's `*testing.T` (`tr.t`) when executed from within a subtest context.

## Solution

1. **`setupClient` now accepts `*testing.T`** - Callers pass the correct test context
2. **`RunBatch` pre-filters providers** - Checks for API keys before attempting to create clients, avoiding the skip-from-wrong-context issue
3. **Added `HasAvailableProviders()` helper** - Allows tests to skip early when no providers have API keys configured
4. **Updated `TestBatchIntegration`** - Uses the new helper to skip gracefully

## Before
```
--- FAIL: TestBasicInteraction (0.00s)
    --- FAIL: TestBasicInteraction/anthropic (0.00s)
        testing.go:1811: test executed panic(nil) or runtime.Goexit
```

## After
```
--- PASS: TestBasicInteraction (0.00s)
    --- SKIP: TestBasicInteraction/anthropic (0.00s)
```

## Testing
```bash
go test -v github.com/teilomillet/gollm/assess
# All tests pass/skip correctly
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches test execution/concurrency and provider selection logic, so behavior changes could alter which tests run and how metrics/errors are recorded. Core runtime behavior changes in `llm/memory.go` may subtly affect prompt construction across providers.
> 
> **Overview**
> Makes `assess` integration/batch tests *skip cleanly* when provider API keys aren’t configured, avoiding subtest panics and nil-metric crashes.
> 
> Adds provider API-key helpers on `TestProvider` plus `TestRunner.HasAvailableProviders()`, and updates both `Run()` and `RunBatch()` to pre-filter providers, early-return when no providers/cases exist, and create a fresh LLM client per test case to avoid concurrent `SetOption` races. Batch latency reporting is also corrected to compute a true arithmetic mean and metrics/logging now handle `nil` `batchMetrics`.
> 
> Separately, `llm/memory.go` now preserves more `Prompt` fields (e.g., `Output`, `Directives`, `Context`, etc.) when constructing the internal prompt for both structured-message and flattened-memory generation paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d73c17f0a8664644c8a5f8fb8e7f2f52c480baba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Summary by Sourcery

Ensure assess tests use the correct testing context when skipping or failing based on provider API key availability.

Bug Fixes:
- Fix incorrect use of the parent *testing.T when skipping tests due to missing provider API keys, preventing Go test runtime panics.

Enhancements:
- Add provider pre-filtering in batch runs so only providers with configured API keys are executed, with logging for skipped providers.
- Introduce a HasAvailableProviders helper to detect configured providers with API keys and allow early test skipping.
- Update batch execution metrics and logging to reflect only the actually available providers.

Tests:
- Adjust TestBatchIntegration to use HasAvailableProviders and skip cleanly when no providers are configured.