### PR TITLE
feat(vision): add multimodal image support for vision-capable models

### DIFF
--- a/examples/vision/main.go
+++ b/examples/vision/main.go
@@ -1,5 +1,5 @@
 // Package main demonstrates how to use GoLLM with vision-capable models.
-// This example shows how to send images to models like gpt-4o, claude-sonnet-4, llava, etc.
+// This example shows how to send images to models like gpt-5.2, claude-sonnet-4.5, llava, etc.
 package main
 
 import (
@@ -14,13 +14,13 @@ import (
 func main() {
 	ctx := context.Background()
 
-	// Example 1: Using OpenAI gpt-4o with an image URL
-	fmt.Println("\n=== Example 1: OpenAI gpt-4o with Image URL ===")
+	// Example 1: Using OpenAI GPT-5.2 with an image URL
+	fmt.Println("\n=== Example 1: OpenAI GPT-5.2 with Image URL ===")
 	if apiKey := os.Getenv("OPENAI_API_KEY"); apiKey != "" {
 		llm, err := gollm.NewLLM(
 			gollm.SetProvider("openai"),
 			gollm.SetAPIKey(apiKey),
-			gollm.SetModel("gpt-4o"), // or "gpt-4-turbo"
+			gollm.SetModel("gpt-5.2"), // vision-capable model
 			gollm.SetMaxTokens(1000),
 		)
 		if err != nil {
@@ -46,13 +46,13 @@ func main() {
 		fmt.Println("Skipping: OPENAI_API_KEY not set")
 	}
 
-	// Example 2: Using Anthropic Claude with an image URL
-	fmt.Println("\n=== Example 2: Anthropic Claude with Image URL ===")
+	// Example 2: Using Anthropic Claude Sonnet 4.5 with an image URL
+	fmt.Println("\n=== Example 2: Anthropic Claude Sonnet 4.5 with Image URL ===")
 	if apiKey := os.Getenv("ANTHROPIC_API_KEY"); apiKey != "" {
 		llm, err := gollm.NewLLM(
 			gollm.SetProvider("anthropic"),
 			gollm.SetAPIKey(apiKey),
-			gollm.SetModel("claude-sonnet-4-20250514"), // or any vision-capable Claude model
+			gollm.SetModel("claude-sonnet-4.5"), // or claude-opus-4.5, claude-haiku-4.5
 			gollm.SetMaxTokens(1000),
 		)
 		if err != nil {
@@ -83,7 +83,7 @@ func main() {
 		llm, err := gollm.NewLLM(
 			gollm.SetProvider("openai"),
 			gollm.SetAPIKey(apiKey),
-			gollm.SetModel("gpt-4o"),
+			gollm.SetModel("gpt-5.2"),
 			gollm.SetMaxTokens(500),
 		)
 		if err != nil {
@@ -130,7 +130,7 @@ func main() {
 		llm, err := gollm.NewLLM(
 			gollm.SetProvider("openai"),
 			gollm.SetAPIKey(apiKey),
-			gollm.SetModel("gpt-4o"),
+			gollm.SetModel("gpt-5.2"),
 			gollm.SetMaxTokens(1000),
 		)
 		if err != nil {
@@ -159,7 +159,7 @@ func main() {
 		llm, err := gollm.NewLLM(
 			gollm.SetProvider("openrouter"),
 			gollm.SetAPIKey(apiKey),
-			gollm.SetModel("anthropic/claude-3-5-sonnet"), // Vision-capable model via OpenRouter
+			gollm.SetModel("anthropic/claude-sonnet-4.5"), // Vision-capable model via OpenRouter
 			gollm.SetMaxTokens(1000),
 		)
 		if err != nil {

--- a/examples/vision/main.go
+++ b/examples/vision/main.go
@@ -1,0 +1,228 @@
+// Package main demonstrates how to use GoLLM with vision-capable models.
+// This example shows how to send images to models like GPT-4V, Claude 3, etc.
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"os"
+
+	"github.com/teilomillet/gollm"
+)
+
+func main() {
+	ctx := context.Background()
+
+	// Example 1: Using OpenAI GPT-4V with an image URL
+	fmt.Println("\n=== Example 1: OpenAI GPT-4V with Image URL ===")
+	if apiKey := os.Getenv("OPENAI_API_KEY"); apiKey != "" {
+		llm, err := gollm.NewLLM(
+			gollm.SetProvider("openai"),
+			gollm.SetAPIKey(apiKey),
+			gollm.SetModel("gpt-4o"), // or "gpt-4-vision-preview"
+			gollm.SetMaxTokens(1000),
+		)
+		if err != nil {
+			fmt.Printf("Error creating OpenAI LLM: %v\n", err)
+		} else {
+			// Create a prompt with an image URL
+			prompt := gollm.NewPrompt(
+				"What's in this image? Please describe it in detail.",
+				gollm.WithImageURL(
+					"https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/PNG_transparency_demonstration_1.png/300px-PNG_transparency_demonstration_1.png",
+					"auto", // detail level: "auto", "low", or "high"
+				),
+			)
+
+			response, err := llm.Generate(ctx, prompt)
+			if err != nil {
+				fmt.Printf("Error: %v\n", err)
+			} else {
+				fmt.Printf("Response: %s\n", response)
+			}
+		}
+	} else {
+		fmt.Println("Skipping: OPENAI_API_KEY not set")
+	}
+
+	// Example 2: Using Anthropic Claude 3 with an image URL
+	fmt.Println("\n=== Example 2: Anthropic Claude 3 with Image URL ===")
+	if apiKey := os.Getenv("ANTHROPIC_API_KEY"); apiKey != "" {
+		llm, err := gollm.NewLLM(
+			gollm.SetProvider("anthropic"),
+			gollm.SetAPIKey(apiKey),
+			gollm.SetModel("claude-sonnet-4-20250514"), // or any Claude 3+ model
+			gollm.SetMaxTokens(1000),
+		)
+		if err != nil {
+			fmt.Printf("Error creating Anthropic LLM: %v\n", err)
+		} else {
+			prompt := gollm.NewPrompt(
+				"Describe this image in detail.",
+				gollm.WithImageURL(
+					"https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/PNG_transparency_demonstration_1.png/300px-PNG_transparency_demonstration_1.png",
+					"auto",
+				),
+			)
+
+			response, err := llm.Generate(ctx, prompt)
+			if err != nil {
+				fmt.Printf("Error: %v\n", err)
+			} else {
+				fmt.Printf("Response: %s\n", response)
+			}
+		}
+	} else {
+		fmt.Println("Skipping: ANTHROPIC_API_KEY not set")
+	}
+
+	// Example 3: Using a base64-encoded image
+	fmt.Println("\n=== Example 3: Using Base64-encoded Image ===")
+	if apiKey := os.Getenv("OPENAI_API_KEY"); apiKey != "" {
+		llm, err := gollm.NewLLM(
+			gollm.SetProvider("openai"),
+			gollm.SetAPIKey(apiKey),
+			gollm.SetModel("gpt-4o"),
+			gollm.SetMaxTokens(500),
+		)
+		if err != nil {
+			fmt.Printf("Error creating LLM: %v\n", err)
+		} else {
+			// In a real application, you would read the image from a file:
+			// imageData, err := os.ReadFile("path/to/image.png")
+			// base64Data := base64.StdEncoding.EncodeToString(imageData)
+
+			// For this example, we'll create a tiny 1x1 pixel PNG
+			// This is a minimal valid PNG (red pixel)
+			tinyPNG := []byte{
+				0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, // PNG signature
+				0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52, // IHDR chunk
+				0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+				0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53,
+				0xDE, 0x00, 0x00, 0x00, 0x0C, 0x49, 0x44, 0x41, // IDAT chunk
+				0x54, 0x08, 0xD7, 0x63, 0xF8, 0xCF, 0xC0, 0x00,
+				0x00, 0x00, 0x03, 0x00, 0x01, 0x00, 0x05, 0xFE,
+				0xD4, 0xEF, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, // IEND chunk
+				0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+			}
+			base64Data := base64.StdEncoding.EncodeToString(tinyPNG)
+
+			prompt := gollm.NewPrompt(
+				"What color is this single pixel image?",
+				gollm.WithImageBase64(base64Data, "image/png"),
+			)
+
+			response, err := llm.Generate(ctx, prompt)
+			if err != nil {
+				fmt.Printf("Error: %v\n", err)
+			} else {
+				fmt.Printf("Response: %s\n", response)
+			}
+		}
+	} else {
+		fmt.Println("Skipping: OPENAI_API_KEY not set")
+	}
+
+	// Example 4: Multiple images in a single prompt
+	fmt.Println("\n=== Example 4: Multiple Images ===")
+	if apiKey := os.Getenv("OPENAI_API_KEY"); apiKey != "" {
+		llm, err := gollm.NewLLM(
+			gollm.SetProvider("openai"),
+			gollm.SetAPIKey(apiKey),
+			gollm.SetModel("gpt-4o"),
+			gollm.SetMaxTokens(1000),
+		)
+		if err != nil {
+			fmt.Printf("Error creating LLM: %v\n", err)
+		} else {
+			prompt := gollm.NewPrompt(
+				"Compare these two images. What are the similarities and differences?",
+				gollm.WithImageURL("https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/PNG_transparency_demonstration_1.png/300px-PNG_transparency_demonstration_1.png", "auto"),
+				gollm.WithImageURL("https://upload.wikimedia.org/wikipedia/commons/thumb/a/a7/Camponotus_flavomarginatus_ant.jpg/320px-Camponotus_flavomarginatus_ant.jpg", "auto"),
+			)
+
+			response, err := llm.Generate(ctx, prompt)
+			if err != nil {
+				fmt.Printf("Error: %v\n", err)
+			} else {
+				fmt.Printf("Response: %s\n", response)
+			}
+		}
+	} else {
+		fmt.Println("Skipping: OPENAI_API_KEY not set")
+	}
+
+	// Example 5: Using OpenRouter with vision models
+	fmt.Println("\n=== Example 5: OpenRouter with Vision Model ===")
+	if apiKey := os.Getenv("OPENROUTER_API_KEY"); apiKey != "" {
+		llm, err := gollm.NewLLM(
+			gollm.SetProvider("openrouter"),
+			gollm.SetAPIKey(apiKey),
+			gollm.SetModel("anthropic/claude-3-5-sonnet"), // Vision-capable model via OpenRouter
+			gollm.SetMaxTokens(1000),
+		)
+		if err != nil {
+			fmt.Printf("Error creating OpenRouter LLM: %v\n", err)
+		} else {
+			prompt := gollm.NewPrompt(
+				"What do you see in this image?",
+				gollm.WithImageURL(
+					"https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/PNG_transparency_demonstration_1.png/300px-PNG_transparency_demonstration_1.png",
+					"auto",
+				),
+			)
+
+			response, err := llm.Generate(ctx, prompt)
+			if err != nil {
+				fmt.Printf("Error: %v\n", err)
+			} else {
+				fmt.Printf("Response: %s\n", response)
+			}
+		}
+	} else {
+		fmt.Println("Skipping: OPENROUTER_API_KEY not set")
+	}
+
+	// Example 6: Using Ollama with vision models (like llava, bakllava)
+	// Note: Ollama requires base64-encoded images, not URLs
+	fmt.Println("\n=== Example 6: Ollama with Vision Model (llava) ===")
+	fmt.Println("Note: Ollama vision models require base64-encoded images")
+	// Check if Ollama is running by attempting to create an LLM
+	llm, err := gollm.NewLLM(
+		gollm.SetProvider("ollama"),
+		gollm.SetModel("llava"), // or "bakllava", "llava:13b", etc.
+		gollm.SetMaxTokens(500),
+	)
+	if err != nil {
+		fmt.Printf("Skipping: Could not connect to Ollama: %v\n", err)
+	} else {
+		// Use the same tiny PNG from Example 3
+		tinyPNG := []byte{
+			0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A,
+			0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+			0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01,
+			0x08, 0x02, 0x00, 0x00, 0x00, 0x90, 0x77, 0x53,
+			0xDE, 0x00, 0x00, 0x00, 0x0C, 0x49, 0x44, 0x41,
+			0x54, 0x08, 0xD7, 0x63, 0xF8, 0xCF, 0xC0, 0x00,
+			0x00, 0x00, 0x03, 0x00, 0x01, 0x00, 0x05, 0xFE,
+			0xD4, 0xEF, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45,
+			0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+		}
+		base64Data := base64.StdEncoding.EncodeToString(tinyPNG)
+
+		prompt := gollm.NewPrompt(
+			"Describe this image. What color is the pixel?",
+			gollm.WithImageBase64(base64Data, "image/png"),
+		)
+
+		response, err := llm.Generate(ctx, prompt)
+		if err != nil {
+			fmt.Printf("Error (is llava model installed?): %v\n", err)
+		} else {
+			fmt.Printf("Response: %s\n", response)
+		}
+	}
+
+	fmt.Println("\n=== Vision Examples Complete ===")
+}

--- a/examples/vision/main.go
+++ b/examples/vision/main.go
@@ -1,5 +1,5 @@
 // Package main demonstrates how to use GoLLM with vision-capable models.
-// This example shows how to send images to models like GPT-4V, Claude 3, etc.
+// This example shows how to send images to models like gpt-4o, claude-sonnet-4, llava, etc.
 package main
 
 import (
@@ -14,13 +14,13 @@ import (
 func main() {
 	ctx := context.Background()
 
-	// Example 1: Using OpenAI GPT-4V with an image URL
-	fmt.Println("\n=== Example 1: OpenAI GPT-4V with Image URL ===")
+	// Example 1: Using OpenAI gpt-4o with an image URL
+	fmt.Println("\n=== Example 1: OpenAI gpt-4o with Image URL ===")
 	if apiKey := os.Getenv("OPENAI_API_KEY"); apiKey != "" {
 		llm, err := gollm.NewLLM(
 			gollm.SetProvider("openai"),
 			gollm.SetAPIKey(apiKey),
-			gollm.SetModel("gpt-4o"), // or "gpt-4-vision-preview"
+			gollm.SetModel("gpt-4o"), // or "gpt-4-turbo"
 			gollm.SetMaxTokens(1000),
 		)
 		if err != nil {
@@ -46,13 +46,13 @@ func main() {
 		fmt.Println("Skipping: OPENAI_API_KEY not set")
 	}
 
-	// Example 2: Using Anthropic Claude 3 with an image URL
-	fmt.Println("\n=== Example 2: Anthropic Claude 3 with Image URL ===")
+	// Example 2: Using Anthropic Claude with an image URL
+	fmt.Println("\n=== Example 2: Anthropic Claude with Image URL ===")
 	if apiKey := os.Getenv("ANTHROPIC_API_KEY"); apiKey != "" {
 		llm, err := gollm.NewLLM(
 			gollm.SetProvider("anthropic"),
 			gollm.SetAPIKey(apiKey),
-			gollm.SetModel("claude-sonnet-4-20250514"), // or any Claude 3+ model
+			gollm.SetModel("claude-sonnet-4-20250514"), // or any vision-capable Claude model
 			gollm.SetMaxTokens(1000),
 		)
 		if err != nil {

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -235,6 +235,11 @@ func (l *LLMImpl) attemptGenerate(ctx context.Context, prompt *Prompt) (string, 
 		options["tool_choice"] = prompt.ToolChoice
 	}
 
+	// Add Images to options for vision-capable models
+	if prompt.HasImages() {
+		options["images"] = prompt.Images
+	}
+
 	var reqBody []byte
 	var err error
 

--- a/llm/prompt.go
+++ b/llm/prompt.go
@@ -20,14 +20,15 @@ const (
 
 // PromptMessage represents a single message in a conversation with an LLM.
 // It can be a system message, user message, or assistant message, and may include
-// tool calls and caching configuration.
+// tool calls, images, and caching configuration.
 type PromptMessage struct {
-	Role       string     `json:"role"`                   // Role of the message sender (e.g., "system", "user", "assistant")
-	Content    string     `json:"content"`                // The actual message content
-	CacheType  CacheType  `json:"cache_type,omitempty"`   // Optional caching strategy for this message
-	Name       string     `json:"name,omitempty"`         // Optional name identifier for the message
-	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`   // Optional tool calls requested by the LLM
-	ToolCallID string     `json:"tool_call_id,omitempty"` // ID of the tool call this message responds to
+	Role         string              `json:"role"`                    // Role of the message sender (e.g., "system", "user", "assistant")
+	Content      string              `json:"content"`                 // The actual message content (text-only)
+	MultiContent []types.ContentPart `json:"multi_content,omitempty"` // Multimodal content (text + images)
+	CacheType    CacheType           `json:"cache_type,omitempty"`    // Optional caching strategy for this message
+	Name         string              `json:"name,omitempty"`          // Optional name identifier for the message
+	ToolCalls    []ToolCall          `json:"tool_calls,omitempty"`    // Optional tool calls requested by the LLM
+	ToolCallID   string              `json:"tool_call_id,omitempty"`  // ID of the tool call this message responds to
 }
 
 // ToolCall represents a request from the LLM to use a specific tool.
@@ -38,7 +39,7 @@ type ToolCall = types.ToolCall
 
 // Prompt represents a complete prompt structure that can be sent to an LLM.
 // It includes various components like system messages, user input, context,
-// and optional elements like tools and examples.
+// and optional elements like tools, images, and examples.
 type Prompt struct {
 	Input           string                 `json:"input" jsonschema:"required,description=The main input text for the LLM" validate:"required"`
 	Output          string                 `json:"output,omitempty" jsonschema:"description=Specification for the expected output format"`
@@ -51,6 +52,7 @@ type Prompt struct {
 	Messages        []PromptMessage        `json:"messages,omitempty" jsonschema:"description=List of messages for the conversation"`
 	Tools           []utils.Tool           `json:"tools,omitempty" jsonschema:"description=Available tools for the LLM to use"`
 	ToolChoice      map[string]interface{} `json:"tool_choice,omitempty" jsonschema:"description=Configuration for tool selection behavior"`
+	Images          []types.ContentPart    `json:"images,omitempty" jsonschema:"description=Images to include with the prompt"`
 }
 
 // PromptOption is a function type that modifies a Prompt.
@@ -214,6 +216,58 @@ func WithExamples(examples ...string) PromptOption {
 			p.Examples = append(p.Examples, examples...)
 		}
 	}
+}
+
+// WithImageURL adds an image from a URL to the prompt.
+// This is used for vision-capable models like GPT-4V, Claude 3, etc.
+//
+// Parameters:
+//   - url: URL of the image (can also be a data URI like "data:image/jpeg;base64,...")
+//   - detail: Detail level for processing ("auto", "low", or "high"). Empty defaults to "auto".
+//
+// Example:
+//
+//	prompt := NewPrompt("What's in this image?",
+//	    WithImageURL("https://example.com/image.jpg", "auto"),
+//	)
+func WithImageURL(url string, detail string) PromptOption {
+	return func(p *Prompt) {
+		p.Images = append(p.Images, types.NewImageURLContent(url, detail))
+	}
+}
+
+// WithImageBase64 adds a base64-encoded image to the prompt.
+// This is used for vision-capable models like GPT-4V, Claude 3, etc.
+//
+// Parameters:
+//   - base64Data: Base64-encoded image data (without the data URI prefix)
+//   - mediaType: MIME type of the image ("image/jpeg", "image/png", "image/gif", "image/webp")
+//
+// Example:
+//
+//	imageData := base64.StdEncoding.EncodeToString(imageBytes)
+//	prompt := NewPrompt("Describe this image",
+//	    WithImageBase64(imageData, "image/png"),
+//	)
+func WithImageBase64(base64Data, mediaType string) PromptOption {
+	return func(p *Prompt) {
+		p.Images = append(p.Images, types.NewImageBase64Content(base64Data, mediaType))
+	}
+}
+
+// WithImages adds multiple images to the prompt.
+//
+// Parameters:
+//   - images: Slice of ContentPart representing images
+func WithImages(images []types.ContentPart) PromptOption {
+	return func(p *Prompt) {
+		p.Images = append(p.Images, images...)
+	}
+}
+
+// HasImages returns true if the prompt contains any images.
+func (p *Prompt) HasImages() bool {
+	return len(p.Images) > 0
 }
 
 // Apply applies the given options to modify the prompt's configuration.

--- a/prompt.go
+++ b/prompt.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/teilomillet/gollm/config"
 	"github.com/teilomillet/gollm/llm"
+	"github.com/teilomillet/gollm/types"
 	"github.com/teilomillet/gollm/utils"
 )
 
@@ -54,6 +55,16 @@ type (
 	// PromptTemplate defines a reusable template for generating prompts.
 	// Templates can include variables that are filled in at runtime.
 	PromptTemplate = llm.PromptTemplate
+
+	// ContentPart represents a single part of multimodal content (text or image).
+	// Used for vision-capable models that can process both text and images.
+	ContentPart = types.ContentPart
+
+	// ImageURL represents an image specified by URL for vision models.
+	ImageURL = types.ImageURL
+
+	// ImageSource represents a base64-encoded image for vision models.
+	ImageSource = types.ImageSource
 )
 
 // Cache type constants define the available caching strategies.
@@ -116,6 +127,17 @@ var (
 
 	// WithStream enables or disables streaming responses.
 	WithStream = config.WithStream
+
+	// WithImageURL adds an image by URL to the prompt for vision-capable models.
+	// The detail parameter controls image processing quality: "auto", "low", or "high".
+	WithImageURL = llm.WithImageURL
+
+	// WithImageBase64 adds a base64-encoded image to the prompt for vision-capable models.
+	// The mediaType should specify the image format (e.g., "image/png", "image/jpeg").
+	WithImageBase64 = llm.WithImageBase64
+
+	// WithImages adds multiple images to the prompt for vision-capable models.
+	WithImages = llm.WithImages
 )
 
 // CleanResponse processes and cleans up LLM responses by removing markdown formatting

--- a/providers/anthropic.go
+++ b/providers/anthropic.go
@@ -665,19 +665,9 @@ func (p *AnthropicProvider) PrepareRequestWithMessages(messages []types.MemoryMe
 			continue
 		}
 
-		// Check if message has multimodal content - use shared helper
+		// Check if message has multimodal content
 		if msg.HasMultiContent() {
-			// Handle multimodal content (text + images)
-			for _, part := range msg.MultiContent {
-				if part.Type == types.ContentTypeText {
-					content = append(content, map[string]interface{}{
-						"type": "text",
-						"text": part.Text,
-					})
-				} else if imgContent, ok := ContentPartToAnthropicImage(part); ok {
-					content = append(content, imgContent)
-				}
-			}
+			content = BuildAnthropicContentFromParts(msg.MultiContent)
 		} else {
 			// Regular text message
 			content = []map[string]interface{}{

--- a/providers/ollama.go
+++ b/providers/ollama.go
@@ -138,6 +138,23 @@ func (p *OllamaProvider) PrepareRequest(prompt string, options map[string]interf
 		"prompt": prompt,
 	}
 
+	// Handle images for vision models (like llava, bakllava, etc.)
+	if images, ok := options["images"].([]types.ContentPart); ok && len(images) > 0 {
+		base64Images := []string{}
+		for _, img := range images {
+			if img.Source != nil && img.Source.Data != "" {
+				// Base64 encoded image
+				base64Images = append(base64Images, img.Source.Data)
+			}
+			// Note: Ollama doesn't support URL-based images directly,
+			// they need to be fetched and base64-encoded first
+		}
+		if len(base64Images) > 0 {
+			requestBody["images"] = base64Images
+		}
+		delete(options, "images")
+	}
+
 	for k, v := range options {
 		requestBody[k] = v
 	}
@@ -305,6 +322,9 @@ func (p *OllamaProvider) PrepareRequestWithMessages(messages []types.MemoryMessa
 	// Convert to flattened format
 	var flattenedPrompt strings.Builder
 
+	// Collect any images from messages
+	var allImages []string
+
 	// Add system prompt if present
 	if systemPrompt, ok := options["system_prompt"].(string); ok && systemPrompt != "" {
 		flattenedPrompt.WriteString("System: ")
@@ -316,10 +336,43 @@ func (p *OllamaProvider) PrepareRequestWithMessages(messages []types.MemoryMessa
 	for _, msg := range messages {
 		flattenedPrompt.WriteString(msg.Role)
 		flattenedPrompt.WriteString(": ")
-		flattenedPrompt.WriteString(msg.Content)
+		if msg.HasMultiContent() {
+			flattenedPrompt.WriteString(msg.GetTextContent())
+			// Extract images from multi-content messages
+			for _, part := range msg.MultiContent {
+				if part.Source != nil && part.Source.Data != "" {
+					allImages = append(allImages, part.Source.Data)
+				}
+			}
+		} else {
+			flattenedPrompt.WriteString(msg.Content)
+		}
 		flattenedPrompt.WriteString("\n\n")
 	}
 
-	// Use regular prompt preparation with flattened text
-	return p.PrepareRequest(flattenedPrompt.String(), options)
+	// Handle images passed in options
+	if images, ok := options["images"].([]types.ContentPart); ok && len(images) > 0 {
+		for _, img := range images {
+			if img.Source != nil && img.Source.Data != "" {
+				allImages = append(allImages, img.Source.Data)
+			}
+		}
+		delete(options, "images")
+	}
+
+	requestBody := map[string]interface{}{
+		"model":  p.model,
+		"prompt": flattenedPrompt.String(),
+	}
+
+	// Add images if present
+	if len(allImages) > 0 {
+		requestBody["images"] = allImages
+	}
+
+	for k, v := range options {
+		requestBody[k] = v
+	}
+
+	return json.Marshal(requestBody)
 }

--- a/providers/openai.go
+++ b/providers/openai.go
@@ -646,19 +646,8 @@ func (p *OpenAIProvider) PrepareRequestWithMessages(messages []types.MemoryMessa
 				message["content"] = msg.Content
 			}
 		} else if msg.HasMultiContent() {
-			// Handle multimodal content (text + images) using shared helper
-			content := make([]map[string]interface{}, 0, len(msg.MultiContent))
-			for _, part := range msg.MultiContent {
-				if part.Type == types.ContentTypeText {
-					content = append(content, map[string]interface{}{
-						"type": "text",
-						"text": part.Text,
-					})
-				} else if imgContent, ok := ContentPartToOpenAIImage(part); ok {
-					content = append(content, imgContent)
-				}
-			}
-			message["content"] = content
+			// Handle multimodal content (text + images)
+			message["content"] = BuildOpenAIContentFromParts(msg.MultiContent)
 		} else {
 			// Regular text message
 			message["content"] = msg.Content

--- a/providers/openrouter.go
+++ b/providers/openrouter.go
@@ -609,20 +609,9 @@ func (p *OpenRouterProvider) PrepareRequestWithMessages(messages []types.MemoryM
 			"role": msg.Role,
 		}
 
-		// Check if message has multimodal content (images) - use shared helper
+		// Check if message has multimodal content (images)
 		if msg.HasMultiContent() {
-			contentArray := []map[string]interface{}{}
-			for _, part := range msg.MultiContent {
-				if part.Type == types.ContentTypeText {
-					contentArray = append(contentArray, map[string]interface{}{
-						"type": "text",
-						"text": part.Text,
-					})
-				} else if imgContent, ok := ContentPartToOpenAIImage(part); ok {
-					contentArray = append(contentArray, imgContent)
-				}
-			}
-			formattedMsg["content"] = contentArray
+			formattedMsg["content"] = BuildOpenAIContentFromParts(msg.MultiContent)
 		} else {
 			formattedMsg["content"] = msg.Content
 

--- a/providers/vision_helpers.go
+++ b/providers/vision_helpers.go
@@ -1,0 +1,164 @@
+// Package providers implements LLM provider interfaces and implementations.
+package providers
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/teilomillet/gollm/types"
+)
+
+// dataURIPattern matches data URIs like "data:image/png;base64,..."
+var dataURIPattern = regexp.MustCompile(`^data:([^;,]+)(?:;[^,]*)?,(.*)$`)
+
+// ParseDataURI extracts the media type and data from a data URI.
+// Returns mediaType, data, and whether parsing was successful.
+// Example: "data:image/png;base64,iVBORw0..." returns "image/png", "iVBORw0...", true
+func ParseDataURI(dataURI string) (mediaType, data string, ok bool) {
+	if !strings.HasPrefix(dataURI, "data:") {
+		return "", "", false
+	}
+
+	matches := dataURIPattern.FindStringSubmatch(dataURI)
+	if len(matches) < 3 {
+		return "", "", false
+	}
+
+	return matches[1], matches[2], true
+}
+
+// ContentPartToOpenAIImage converts a ContentPart to OpenAI-style image_url format.
+// Returns the formatted map and whether conversion was successful.
+func ContentPartToOpenAIImage(part types.ContentPart) (map[string]interface{}, bool) {
+	switch part.Type {
+	case types.ContentTypeImageURL:
+		if part.ImageURL == nil {
+			return nil, false
+		}
+		imgContent := map[string]interface{}{
+			"type": "image_url",
+			"image_url": map[string]interface{}{
+				"url": part.ImageURL.URL,
+			},
+		}
+		if part.ImageURL.Detail != "" {
+			imgContent["image_url"].(map[string]interface{})["detail"] = part.ImageURL.Detail
+		}
+		return imgContent, true
+
+	case types.ContentTypeImage:
+		if part.Source == nil || part.Source.Data == "" {
+			return nil, false
+		}
+		// Convert base64 to data URI for OpenAI-compatible format
+		dataURI := fmt.Sprintf("data:%s;base64,%s", part.Source.MediaType, part.Source.Data)
+		return map[string]interface{}{
+			"type": "image_url",
+			"image_url": map[string]interface{}{
+				"url": dataURI,
+			},
+		}, true
+
+	default:
+		return nil, false
+	}
+}
+
+// ContentPartToAnthropicImage converts a ContentPart to Anthropic-style image format.
+// Returns the formatted map and whether conversion was successful.
+func ContentPartToAnthropicImage(part types.ContentPart) (map[string]interface{}, bool) {
+	switch part.Type {
+	case types.ContentTypeImage:
+		// Direct base64 image
+		if part.Source == nil || part.Source.Data == "" {
+			return nil, false
+		}
+		return map[string]interface{}{
+			"type": "image",
+			"source": map[string]interface{}{
+				"type":       "base64",
+				"media_type": part.Source.MediaType,
+				"data":       part.Source.Data,
+			},
+		}, true
+
+	case types.ContentTypeImageURL:
+		if part.ImageURL == nil {
+			return nil, false
+		}
+		// Check if it's a data URI (base64)
+		if mediaType, data, ok := ParseDataURI(part.ImageURL.URL); ok {
+			return map[string]interface{}{
+				"type": "image",
+				"source": map[string]interface{}{
+					"type":       "base64",
+					"media_type": mediaType,
+					"data":       data,
+				},
+			}, true
+		}
+		// Regular URL - Anthropic supports URL source type
+		return map[string]interface{}{
+			"type": "image",
+			"source": map[string]interface{}{
+				"type": "url",
+				"url":  part.ImageURL.URL,
+			},
+		}, true
+
+	default:
+		return nil, false
+	}
+}
+
+// ConvertImagesToOpenAIContent converts a slice of ContentPart images to OpenAI format.
+// Returns a slice of formatted image objects.
+func ConvertImagesToOpenAIContent(images []types.ContentPart) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(images))
+	for _, img := range images {
+		if converted, ok := ContentPartToOpenAIImage(img); ok {
+			result = append(result, converted)
+		}
+	}
+	return result
+}
+
+// ConvertImagesToAnthropicContent converts a slice of ContentPart images to Anthropic format.
+// Returns a slice of formatted image objects.
+func ConvertImagesToAnthropicContent(images []types.ContentPart) []map[string]interface{} {
+	result := make([]map[string]interface{}, 0, len(images))
+	for _, img := range images {
+		if converted, ok := ContentPartToAnthropicImage(img); ok {
+			result = append(result, converted)
+		}
+	}
+	return result
+}
+
+// NormalizeContentArray safely converts various content representations to []map[string]interface{}.
+// Handles: string, []map[string]interface{}, []interface{}, and nil.
+func NormalizeContentArray(content interface{}) []map[string]interface{} {
+	if content == nil {
+		return []map[string]interface{}{}
+	}
+
+	switch c := content.(type) {
+	case string:
+		return []map[string]interface{}{
+			{"type": "text", "text": c},
+		}
+	case []map[string]interface{}:
+		return c
+	case []interface{}:
+		result := make([]map[string]interface{}, 0, len(c))
+		for _, item := range c {
+			if m, ok := item.(map[string]interface{}); ok {
+				result = append(result, m)
+			}
+		}
+		return result
+	default:
+		return []map[string]interface{}{}
+	}
+}

--- a/providers/vision_helpers.go
+++ b/providers/vision_helpers.go
@@ -136,6 +136,46 @@ func ConvertImagesToAnthropicContent(images []types.ContentPart) []map[string]in
 	return result
 }
 
+// BuildOpenAIContentFromParts converts a slice of ContentPart (text + images) to OpenAI message content.
+// This is the primary helper for building multimodal content arrays.
+func BuildOpenAIContentFromParts(parts []types.ContentPart) []map[string]interface{} {
+	content := make([]map[string]interface{}, 0, len(parts))
+	for _, part := range parts {
+		switch part.Type {
+		case types.ContentTypeText:
+			content = append(content, map[string]interface{}{
+				"type": "text",
+				"text": part.Text,
+			})
+		default:
+			if converted, ok := ContentPartToOpenAIImage(part); ok {
+				content = append(content, converted)
+			}
+		}
+	}
+	return content
+}
+
+// BuildAnthropicContentFromParts converts a slice of ContentPart (text + images) to Anthropic message content.
+// This is the primary helper for building multimodal content arrays.
+func BuildAnthropicContentFromParts(parts []types.ContentPart) []map[string]interface{} {
+	content := make([]map[string]interface{}, 0, len(parts))
+	for _, part := range parts {
+		switch part.Type {
+		case types.ContentTypeText:
+			content = append(content, map[string]interface{}{
+				"type": "text",
+				"text": part.Text,
+			})
+		default:
+			if converted, ok := ContentPartToAnthropicImage(part); ok {
+				content = append(content, converted)
+			}
+		}
+	}
+	return content
+}
+
 // NormalizeContentArray safely converts various content representations to []map[string]interface{}.
 // Handles: string, []map[string]interface{}, []interface{}, and nil.
 func NormalizeContentArray(content interface{}) []map[string]interface{} {

--- a/providers/vision_helpers_test.go
+++ b/providers/vision_helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/teilomillet/gollm/types"
 )
 
@@ -89,9 +90,10 @@ func TestContentPartToOpenAIImage(t *testing.T) {
 			},
 		}
 		result, ok := ContentPartToOpenAIImage(part)
-		assert.True(t, ok)
+		require.True(t, ok, "conversion should succeed")
 		assert.Equal(t, "image_url", result["type"])
-		imgURL := result["image_url"].(map[string]interface{})
+		imgURL, ok := result["image_url"].(map[string]interface{})
+		require.True(t, ok, "image_url should be a map")
 		assert.Equal(t, "https://example.com/image.jpg", imgURL["url"])
 		assert.Equal(t, "high", imgURL["detail"])
 	})
@@ -104,8 +106,9 @@ func TestContentPartToOpenAIImage(t *testing.T) {
 			},
 		}
 		result, ok := ContentPartToOpenAIImage(part)
-		assert.True(t, ok)
-		imgURL := result["image_url"].(map[string]interface{})
+		require.True(t, ok, "conversion should succeed")
+		imgURL, ok := result["image_url"].(map[string]interface{})
+		require.True(t, ok, "image_url should be a map")
 		assert.Equal(t, "https://example.com/image.jpg", imgURL["url"])
 		_, hasDetail := imgURL["detail"]
 		assert.False(t, hasDetail)
@@ -121,9 +124,10 @@ func TestContentPartToOpenAIImage(t *testing.T) {
 			},
 		}
 		result, ok := ContentPartToOpenAIImage(part)
-		assert.True(t, ok)
+		require.True(t, ok, "conversion should succeed")
 		assert.Equal(t, "image_url", result["type"])
-		imgURL := result["image_url"].(map[string]interface{})
+		imgURL, ok := result["image_url"].(map[string]interface{})
+		require.True(t, ok, "image_url should be a map")
 		assert.Equal(t, "data:image/png;base64,iVBORw0KGgo=", imgURL["url"])
 	})
 
@@ -157,9 +161,10 @@ func TestContentPartToAnthropicImage(t *testing.T) {
 			},
 		}
 		result, ok := ContentPartToAnthropicImage(part)
-		assert.True(t, ok)
+		require.True(t, ok, "conversion should succeed")
 		assert.Equal(t, "image", result["type"])
-		source := result["source"].(map[string]interface{})
+		source, ok := result["source"].(map[string]interface{})
+		require.True(t, ok, "source should be a map")
 		assert.Equal(t, "base64", source["type"])
 		assert.Equal(t, "image/png", source["media_type"])
 		assert.Equal(t, "iVBORw0KGgo=", source["data"])
@@ -173,9 +178,10 @@ func TestContentPartToAnthropicImage(t *testing.T) {
 			},
 		}
 		result, ok := ContentPartToAnthropicImage(part)
-		assert.True(t, ok)
+		require.True(t, ok, "conversion should succeed")
 		assert.Equal(t, "image", result["type"])
-		source := result["source"].(map[string]interface{})
+		source, ok := result["source"].(map[string]interface{})
+		require.True(t, ok, "source should be a map")
 		assert.Equal(t, "url", source["type"])
 		assert.Equal(t, "https://example.com/image.jpg", source["url"])
 	})
@@ -188,9 +194,10 @@ func TestContentPartToAnthropicImage(t *testing.T) {
 			},
 		}
 		result, ok := ContentPartToAnthropicImage(part)
-		assert.True(t, ok)
+		require.True(t, ok, "conversion should succeed")
 		assert.Equal(t, "image", result["type"])
-		source := result["source"].(map[string]interface{})
+		source, ok := result["source"].(map[string]interface{})
+		require.True(t, ok, "source should be a map")
 		assert.Equal(t, "base64", source["type"])
 		assert.Equal(t, "image/jpeg", source["media_type"])
 		assert.Equal(t, "/9j/4AAQ=", source["data"])

--- a/providers/vision_helpers_test.go
+++ b/providers/vision_helpers_test.go
@@ -1,0 +1,238 @@
+package providers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/teilomillet/gollm/types"
+)
+
+func TestParseDataURI(t *testing.T) {
+	tests := []struct {
+		name          string
+		input         string
+		wantMediaType string
+		wantData      string
+		wantOK        bool
+	}{
+		{
+			name:          "valid PNG data URI",
+			input:         "data:image/png;base64,iVBORw0KGgo=",
+			wantMediaType: "image/png",
+			wantData:      "iVBORw0KGgo=",
+			wantOK:        true,
+		},
+		{
+			name:          "valid JPEG data URI",
+			input:         "data:image/jpeg;base64,/9j/4AAQ=",
+			wantMediaType: "image/jpeg",
+			wantData:      "/9j/4AAQ=",
+			wantOK:        true,
+		},
+		{
+			name:          "valid WebP data URI",
+			input:         "data:image/webp;base64,UklGR=",
+			wantMediaType: "image/webp",
+			wantData:      "UklGR=",
+			wantOK:        true,
+		},
+		{
+			name:          "valid GIF data URI",
+			input:         "data:image/gif;base64,R0lGODlh",
+			wantMediaType: "image/gif",
+			wantData:      "R0lGODlh",
+			wantOK:        true,
+		},
+		{
+			name:          "data URI without base64 encoding specifier",
+			input:         "data:text/plain,hello",
+			wantMediaType: "text/plain",
+			wantData:      "hello",
+			wantOK:        true,
+		},
+		{
+			name:   "not a data URI",
+			input:  "https://example.com/image.png",
+			wantOK: false,
+		},
+		{
+			name:   "empty string",
+			input:  "",
+			wantOK: false,
+		},
+		{
+			name:   "malformed data URI",
+			input:  "data:",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mediaType, data, ok := ParseDataURI(tt.input)
+			assert.Equal(t, tt.wantOK, ok)
+			if ok {
+				assert.Equal(t, tt.wantMediaType, mediaType)
+				assert.Equal(t, tt.wantData, data)
+			}
+		})
+	}
+}
+
+func TestContentPartToOpenAIImage(t *testing.T) {
+	t.Run("image URL with detail", func(t *testing.T) {
+		part := types.ContentPart{
+			Type: types.ContentTypeImageURL,
+			ImageURL: &types.ImageURL{
+				URL:    "https://example.com/image.jpg",
+				Detail: "high",
+			},
+		}
+		result, ok := ContentPartToOpenAIImage(part)
+		assert.True(t, ok)
+		assert.Equal(t, "image_url", result["type"])
+		imgURL := result["image_url"].(map[string]interface{})
+		assert.Equal(t, "https://example.com/image.jpg", imgURL["url"])
+		assert.Equal(t, "high", imgURL["detail"])
+	})
+
+	t.Run("image URL without detail", func(t *testing.T) {
+		part := types.ContentPart{
+			Type: types.ContentTypeImageURL,
+			ImageURL: &types.ImageURL{
+				URL: "https://example.com/image.jpg",
+			},
+		}
+		result, ok := ContentPartToOpenAIImage(part)
+		assert.True(t, ok)
+		imgURL := result["image_url"].(map[string]interface{})
+		assert.Equal(t, "https://example.com/image.jpg", imgURL["url"])
+		_, hasDetail := imgURL["detail"]
+		assert.False(t, hasDetail)
+	})
+
+	t.Run("base64 image", func(t *testing.T) {
+		part := types.ContentPart{
+			Type: types.ContentTypeImage,
+			Source: &types.ImageSource{
+				Type:      "base64",
+				MediaType: "image/png",
+				Data:      "iVBORw0KGgo=",
+			},
+		}
+		result, ok := ContentPartToOpenAIImage(part)
+		assert.True(t, ok)
+		assert.Equal(t, "image_url", result["type"])
+		imgURL := result["image_url"].(map[string]interface{})
+		assert.Equal(t, "data:image/png;base64,iVBORw0KGgo=", imgURL["url"])
+	})
+
+	t.Run("nil ImageURL returns false", func(t *testing.T) {
+		part := types.ContentPart{
+			Type:     types.ContentTypeImageURL,
+			ImageURL: nil,
+		}
+		_, ok := ContentPartToOpenAIImage(part)
+		assert.False(t, ok)
+	})
+
+	t.Run("nil Source returns false", func(t *testing.T) {
+		part := types.ContentPart{
+			Type:   types.ContentTypeImage,
+			Source: nil,
+		}
+		_, ok := ContentPartToOpenAIImage(part)
+		assert.False(t, ok)
+	})
+}
+
+func TestContentPartToAnthropicImage(t *testing.T) {
+	t.Run("base64 image", func(t *testing.T) {
+		part := types.ContentPart{
+			Type: types.ContentTypeImage,
+			Source: &types.ImageSource{
+				Type:      "base64",
+				MediaType: "image/png",
+				Data:      "iVBORw0KGgo=",
+			},
+		}
+		result, ok := ContentPartToAnthropicImage(part)
+		assert.True(t, ok)
+		assert.Equal(t, "image", result["type"])
+		source := result["source"].(map[string]interface{})
+		assert.Equal(t, "base64", source["type"])
+		assert.Equal(t, "image/png", source["media_type"])
+		assert.Equal(t, "iVBORw0KGgo=", source["data"])
+	})
+
+	t.Run("URL image", func(t *testing.T) {
+		part := types.ContentPart{
+			Type: types.ContentTypeImageURL,
+			ImageURL: &types.ImageURL{
+				URL: "https://example.com/image.jpg",
+			},
+		}
+		result, ok := ContentPartToAnthropicImage(part)
+		assert.True(t, ok)
+		assert.Equal(t, "image", result["type"])
+		source := result["source"].(map[string]interface{})
+		assert.Equal(t, "url", source["type"])
+		assert.Equal(t, "https://example.com/image.jpg", source["url"])
+	})
+
+	t.Run("data URI converted to base64", func(t *testing.T) {
+		part := types.ContentPart{
+			Type: types.ContentTypeImageURL,
+			ImageURL: &types.ImageURL{
+				URL: "data:image/jpeg;base64,/9j/4AAQ=",
+			},
+		}
+		result, ok := ContentPartToAnthropicImage(part)
+		assert.True(t, ok)
+		assert.Equal(t, "image", result["type"])
+		source := result["source"].(map[string]interface{})
+		assert.Equal(t, "base64", source["type"])
+		assert.Equal(t, "image/jpeg", source["media_type"])
+		assert.Equal(t, "/9j/4AAQ=", source["data"])
+	})
+}
+
+func TestNormalizeContentArray(t *testing.T) {
+	t.Run("string content", func(t *testing.T) {
+		result := NormalizeContentArray("hello world")
+		assert.Len(t, result, 1)
+		assert.Equal(t, "text", result[0]["type"])
+		assert.Equal(t, "hello world", result[0]["text"])
+	})
+
+	t.Run("[]map[string]interface{} passthrough", func(t *testing.T) {
+		input := []map[string]interface{}{
+			{"type": "text", "text": "hello"},
+		}
+		result := NormalizeContentArray(input)
+		assert.Equal(t, input, result)
+	})
+
+	t.Run("[]interface{} conversion", func(t *testing.T) {
+		input := []interface{}{
+			map[string]interface{}{"type": "text", "text": "hello"},
+			map[string]interface{}{"type": "image_url", "image_url": map[string]interface{}{"url": "http://example.com"}},
+		}
+		result := NormalizeContentArray(input)
+		assert.Len(t, result, 2)
+		assert.Equal(t, "text", result[0]["type"])
+		assert.Equal(t, "image_url", result[1]["type"])
+	})
+
+	t.Run("nil returns empty slice", func(t *testing.T) {
+		result := NormalizeContentArray(nil)
+		assert.NotNil(t, result)
+		assert.Len(t, result, 0)
+	})
+
+	t.Run("unknown type returns empty slice", func(t *testing.T) {
+		result := NormalizeContentArray(12345)
+		assert.NotNil(t, result)
+		assert.Len(t, result, 0)
+	})
+}

--- a/types/message.go
+++ b/types/message.go
@@ -2,6 +2,78 @@
 // It helps avoid import cycles while providing common data structures.
 package types
 
+// ContentPartType represents the type of content in a multimodal message.
+type ContentPartType string
+
+const (
+	// ContentTypeText represents text content.
+	ContentTypeText ContentPartType = "text"
+	// ContentTypeImageURL represents an image referenced by URL.
+	ContentTypeImageURL ContentPartType = "image_url"
+	// ContentTypeImage represents an image with embedded data (base64).
+	ContentTypeImage ContentPartType = "image"
+)
+
+// ImageURL represents an image referenced by URL.
+// Used by OpenAI and similar providers.
+type ImageURL struct {
+	URL    string `json:"url"`              // URL of the image or base64 data URI
+	Detail string `json:"detail,omitempty"` // Detail level: "auto", "low", or "high"
+}
+
+// ImageSource represents an image with embedded data.
+// Used by Anthropic and similar providers.
+type ImageSource struct {
+	Type      string `json:"type"`       // Source type: "base64"
+	MediaType string `json:"media_type"` // MIME type: "image/jpeg", "image/png", "image/gif", "image/webp"
+	Data      string `json:"data"`       // Base64-encoded image data
+}
+
+// ContentPart represents a single part of multimodal content.
+// A message can contain multiple parts (e.g., text and images).
+type ContentPart struct {
+	Type     ContentPartType `json:"type"`                // Type of content: "text", "image_url", or "image"
+	Text     string          `json:"text,omitempty"`      // Text content (when Type is "text")
+	ImageURL *ImageURL       `json:"image_url,omitempty"` // Image URL (when Type is "image_url")
+	Source   *ImageSource    `json:"source,omitempty"`    // Image source (when Type is "image", used by Anthropic)
+}
+
+// NewTextContent creates a text content part.
+func NewTextContent(text string) ContentPart {
+	return ContentPart{
+		Type: ContentTypeText,
+		Text: text,
+	}
+}
+
+// NewImageURLContent creates an image content part from a URL.
+// The detail parameter can be "auto", "low", or "high" (empty defaults to "auto").
+func NewImageURLContent(url string, detail string) ContentPart {
+	if detail == "" {
+		detail = "auto"
+	}
+	return ContentPart{
+		Type: ContentTypeImageURL,
+		ImageURL: &ImageURL{
+			URL:    url,
+			Detail: detail,
+		},
+	}
+}
+
+// NewImageBase64Content creates an image content part from base64-encoded data.
+// mediaType should be "image/jpeg", "image/png", "image/gif", or "image/webp".
+func NewImageBase64Content(base64Data, mediaType string) ContentPart {
+	return ContentPart{
+		Type: ContentTypeImage,
+		Source: &ImageSource{
+			Type:      "base64",
+			MediaType: mediaType,
+			Data:      base64Data,
+		},
+	}
+}
+
 // MemoryMessage represents a single message in the conversation history.
 // It includes the role of the speaker, the content of the message,
 // and the number of tokens in the message for efficient memory management.
@@ -9,12 +81,38 @@ package types
 // For tool calling support:
 // - Assistant messages may include ToolCalls (requests to use tools)
 // - Tool messages contain ToolCallID (linking result to the original call)
+//
+// For multimodal support:
+// - Use MultiContent for messages with images or mixed content
+// - When MultiContent is set, Content is ignored by providers that support multimodal
 type MemoryMessage struct {
 	Role         string                 // Role of the message sender (e.g., "user", "assistant", "tool")
-	Content      string                 // The actual message content
+	Content      string                 // The actual message content (text-only)
+	MultiContent []ContentPart          // Multimodal content (text + images); takes precedence over Content
 	Tokens       int                    // Number of tokens in the message
 	CacheControl string                 // Caching strategy for this message ("ephemeral", "persistent", etc.)
 	Metadata     map[string]interface{} // Additional provider-specific metadata
 	ToolCalls    []ToolCall             // Tool calls requested by the assistant (only for role="assistant")
 	ToolCallID   string                 // ID of the tool call this message responds to (only for role="tool")
+}
+
+// HasMultiContent returns true if the message contains multimodal content.
+func (m *MemoryMessage) HasMultiContent() bool {
+	return len(m.MultiContent) > 0
+}
+
+// GetTextContent returns the text content of the message.
+// If MultiContent is set, it concatenates all text parts.
+// Otherwise, it returns the Content field.
+func (m *MemoryMessage) GetTextContent() string {
+	if !m.HasMultiContent() {
+		return m.Content
+	}
+	var text string
+	for _, part := range m.MultiContent {
+		if part.Type == ContentTypeText {
+			text += part.Text
+		}
+	}
+	return text
 }

--- a/types/vision_test.go
+++ b/types/vision_test.go
@@ -85,4 +85,38 @@ func TestMemoryMessageMultiContent(t *testing.T) {
 		}
 		assert.Equal(t, "Hello world!", msg.GetTextContent())
 	})
+
+	t.Run("GetTextContent returns empty for image-only MultiContent", func(t *testing.T) {
+		msg := MemoryMessage{
+			Role: "user",
+			MultiContent: []ContentPart{
+				NewImageBase64Content("base64data", "image/png"),
+				NewImageURLContent("https://example.com/img.jpg", "auto"),
+			},
+		}
+		assert.True(t, msg.HasMultiContent())
+		assert.Equal(t, "", msg.GetTextContent())
+	})
+
+	t.Run("GetTextContent prefers MultiContent text over Content field", func(t *testing.T) {
+		msg := MemoryMessage{
+			Role:    "user",
+			Content: "fallback content",
+			MultiContent: []ContentPart{
+				NewTextContent("multi text"),
+				NewImageBase64Content("base64data", "image/png"),
+			},
+		}
+		assert.True(t, msg.HasMultiContent())
+		assert.Equal(t, "multi text", msg.GetTextContent())
+	})
+
+	t.Run("HasMultiContent returns false for empty slice", func(t *testing.T) {
+		msg := MemoryMessage{
+			Role:         "user",
+			Content:      "text only",
+			MultiContent: []ContentPart{},
+		}
+		assert.False(t, msg.HasMultiContent())
+	})
 }

--- a/types/vision_test.go
+++ b/types/vision_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewTextContent(t *testing.T) {
@@ -20,7 +21,7 @@ func TestNewImageURLContent(t *testing.T) {
 		content := NewImageURLContent("https://example.com/image.jpg", "")
 
 		assert.Equal(t, ContentTypeImageURL, content.Type)
-		assert.NotNil(t, content.ImageURL)
+		require.NotNil(t, content.ImageURL, "ImageURL should not be nil")
 		assert.Equal(t, "https://example.com/image.jpg", content.ImageURL.URL)
 		assert.Equal(t, "auto", content.ImageURL.Detail)
 	})
@@ -29,7 +30,7 @@ func TestNewImageURLContent(t *testing.T) {
 		content := NewImageURLContent("https://example.com/image.jpg", "high")
 
 		assert.Equal(t, ContentTypeImageURL, content.Type)
-		assert.NotNil(t, content.ImageURL)
+		require.NotNil(t, content.ImageURL, "ImageURL should not be nil")
 		assert.Equal(t, "https://example.com/image.jpg", content.ImageURL.URL)
 		assert.Equal(t, "high", content.ImageURL.Detail)
 	})
@@ -39,7 +40,7 @@ func TestNewImageBase64Content(t *testing.T) {
 	content := NewImageBase64Content("base64data", "image/png")
 
 	assert.Equal(t, ContentTypeImage, content.Type)
-	assert.NotNil(t, content.Source)
+	require.NotNil(t, content.Source, "Source should not be nil")
 	assert.Equal(t, "base64", content.Source.Type)
 	assert.Equal(t, "image/png", content.Source.MediaType)
 	assert.Equal(t, "base64data", content.Source.Data)

--- a/types/vision_test.go
+++ b/types/vision_test.go
@@ -1,0 +1,87 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewTextContent(t *testing.T) {
+	content := NewTextContent("Hello, world!")
+
+	assert.Equal(t, ContentTypeText, content.Type)
+	assert.Equal(t, "Hello, world!", content.Text)
+	assert.Nil(t, content.ImageURL)
+	assert.Nil(t, content.Source)
+}
+
+func TestNewImageURLContent(t *testing.T) {
+	t.Run("with default detail", func(t *testing.T) {
+		content := NewImageURLContent("https://example.com/image.jpg", "")
+
+		assert.Equal(t, ContentTypeImageURL, content.Type)
+		assert.NotNil(t, content.ImageURL)
+		assert.Equal(t, "https://example.com/image.jpg", content.ImageURL.URL)
+		assert.Equal(t, "auto", content.ImageURL.Detail)
+	})
+
+	t.Run("with high detail", func(t *testing.T) {
+		content := NewImageURLContent("https://example.com/image.jpg", "high")
+
+		assert.Equal(t, ContentTypeImageURL, content.Type)
+		assert.NotNil(t, content.ImageURL)
+		assert.Equal(t, "https://example.com/image.jpg", content.ImageURL.URL)
+		assert.Equal(t, "high", content.ImageURL.Detail)
+	})
+}
+
+func TestNewImageBase64Content(t *testing.T) {
+	content := NewImageBase64Content("base64data", "image/png")
+
+	assert.Equal(t, ContentTypeImage, content.Type)
+	assert.NotNil(t, content.Source)
+	assert.Equal(t, "base64", content.Source.Type)
+	assert.Equal(t, "image/png", content.Source.MediaType)
+	assert.Equal(t, "base64data", content.Source.Data)
+}
+
+func TestMemoryMessageMultiContent(t *testing.T) {
+	t.Run("HasMultiContent returns false for empty", func(t *testing.T) {
+		msg := MemoryMessage{
+			Role:    "user",
+			Content: "text only",
+		}
+		assert.False(t, msg.HasMultiContent())
+	})
+
+	t.Run("HasMultiContent returns true when set", func(t *testing.T) {
+		msg := MemoryMessage{
+			Role: "user",
+			MultiContent: []ContentPart{
+				NewTextContent("Hello"),
+				NewImageURLContent("https://example.com/img.jpg", "auto"),
+			},
+		}
+		assert.True(t, msg.HasMultiContent())
+	})
+
+	t.Run("GetTextContent returns Content when no MultiContent", func(t *testing.T) {
+		msg := MemoryMessage{
+			Role:    "user",
+			Content: "Hello, world!",
+		}
+		assert.Equal(t, "Hello, world!", msg.GetTextContent())
+	})
+
+	t.Run("GetTextContent concatenates text from MultiContent", func(t *testing.T) {
+		msg := MemoryMessage{
+			Role: "user",
+			MultiContent: []ContentPart{
+				NewTextContent("Hello "),
+				NewImageURLContent("https://example.com/img.jpg", "auto"),
+				NewTextContent("world!"),
+			},
+		}
+		assert.Equal(t, "Hello world!", msg.GetTextContent())
+	})
+}


### PR DESCRIPTION
## Summary

- Add comprehensive multimodal/vision support for sending images to LLMs
- Support for OpenAI (gpt-5.2), Anthropic (claude-sonnet-4.5, claude-opus-4.5), Ollama (llava/bakllava), and OpenRouter
- New `WithImageURL` and `WithImageBase64` prompt options for easy image attachment
- Export vision types (`ContentPart`, `ImageURL`, `ImageSource`) from main package

## Changes

### New Features
- `gollm.WithImageURL(url, detail)` - Add image by URL with detail level ("auto", "low", "high")
- `gollm.WithImageBase64(data, mediaType)` - Add base64-encoded image
- `gollm.WithImages(images)` - Add multiple images at once

### Provider Support
- **OpenAI**: Content array with `image_url` type (URL and data URI)
- **Anthropic**: Content blocks with `image` type and `source` object
- **Ollama**: `images` array with base64 strings for llava/bakllava models
- **OpenRouter**: OpenAI-compatible format for all vision models

### New Files
- `examples/vision/main.go` - Comprehensive examples for all providers
- `types/vision_test.go` - Unit tests for vision types

## Test plan

- [x] All existing tests pass
- [x] New vision type tests pass
- [ ] Manual test with OpenAI gpt-5.2 (requires API key)
- [ ] Manual test with Anthropic claude-sonnet-4.5 (requires API key)
- [ ] Manual test with Ollama llava (requires local Ollama)
- [ ] Manual test with OpenRouter (requires API key)

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)