### PR TITLE
Add provider-aware retry with backoff to the Generate path

### DIFF
--- a/config.go
+++ b/config.go
@@ -100,11 +100,12 @@ var (
 	SetTfsZ          = config.SetTfsZ          // Sets tail-free sampling parameter
 
 	// Runtime configuration
-	SetTimeout      = config.SetTimeout      // Sets request timeout duration
-	SetMaxRetries   = config.SetMaxRetries   // Sets maximum retry attempts
-	SetRetryDelay   = config.SetRetryDelay   // Sets delay between retries
-	SetLogLevel     = config.SetLogLevel     // Sets logging verbosity
-	SetExtraHeaders = config.SetExtraHeaders // Sets additional HTTP headers
+	SetTimeout       = config.SetTimeout       // Sets request timeout duration
+	SetMaxRetries    = config.SetMaxRetries    // Sets maximum retry attempts
+	SetRetryDelay    = config.SetRetryDelay    // Sets base delay for retry backoff
+	SetMaxRetryDelay = config.SetMaxRetryDelay // Caps exponential retry backoff
+	SetLogLevel      = config.SetLogLevel      // Sets logging verbosity
+	SetExtraHeaders  = config.SetExtraHeaders  // Sets additional HTTP headers
 
 	// Feature toggles
 	SetEnableCaching = config.SetEnableCaching // Enables/disables response caching

--- a/config/config.go
+++ b/config/config.go
@@ -63,6 +63,7 @@ type Config struct {
 	Timeout               time.Duration     `env:"LLM_TIMEOUT" envDefault:"30s"`
 	MaxRetries            int               `env:"LLM_MAX_RETRIES" envDefault:"3"`
 	RetryDelay            time.Duration     `env:"LLM_RETRY_DELAY" envDefault:"2s"`
+	MaxRetryDelay         time.Duration     `env:"LLM_MAX_RETRY_DELAY" envDefault:"60s"`
 	APIKeys               map[string]string `validate:"required,apikey"`
 	LogLevel              utils.LogLevel    `env:"LLM_LOG_LEVEL" envDefault:"WARN"`
 	Seed                  *int              `env:"LLM_SEED"`
@@ -147,16 +148,17 @@ type ConfigOption func(*Config)
 //	)
 func NewConfig() *Config {
 	return &Config{
-		Provider:     "openai",
-		Model:        "gpt-4o-mini",
-		Temperature:  0.7,
-		MaxTokens:    300,
-		Timeout:      30 * time.Second,
-		MaxRetries:   3,
-		RetryDelay:   2 * time.Second,
-		APIKeys:      make(map[string]string),
-		LogLevel:     utils.LogLevelWarn,
-		ExtraHeaders: make(map[string]string),
+		Provider:      "openai",
+		Model:         "gpt-4o-mini",
+		Temperature:   0.7,
+		MaxTokens:     300,
+		Timeout:       30 * time.Second,
+		MaxRetries:    3,
+		RetryDelay:    2 * time.Second,
+		MaxRetryDelay: 60 * time.Second,
+		APIKeys:       make(map[string]string),
+		LogLevel:      utils.LogLevelWarn,
+		ExtraHeaders:  make(map[string]string),
 	}
 }
 
@@ -242,10 +244,20 @@ func SetMaxRetries(maxRetries int) ConfigOption {
 	}
 }
 
-// SetRetryDelay sets the delay between retries.
+// SetRetryDelay sets the base delay for retry backoff. The retry loop grows
+// this exponentially per attempt (base × 2^attempt) with full jitter, so it is
+// the floor of the backoff curve rather than a fixed inter-attempt delay.
 func SetRetryDelay(retryDelay time.Duration) ConfigOption {
 	return func(c *Config) {
 		c.RetryDelay = retryDelay
+	}
+}
+
+// SetMaxRetryDelay caps the exponential backoff between retries. Zero means
+// uncapped growth from the base RetryDelay.
+func SetMaxRetryDelay(maxRetryDelay time.Duration) ConfigOption {
+	return func(c *Config) {
+		c.MaxRetryDelay = maxRetryDelay
 	}
 }
 

--- a/llm/errors.go
+++ b/llm/errors.go
@@ -2,6 +2,7 @@ package llm
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/teilomillet/gollm/utils"
 )
@@ -46,6 +47,19 @@ type LLMError struct {
 	Type    ErrorType // The category of the error
 	Message string    // A human-readable error message
 	Err     error     // The underlying error, if any
+
+	// Retryable reports whether retrying the request may succeed. It is set
+	// by the classifier for transient network failures and retryable HTTP
+	// statuses (408, 409, 429 rate limits, 5xx); permanent failures (most
+	// 4xx, exhausted quota) leave it false. The retry loop reads this field.
+	Retryable bool
+	// RetryAfter carries a server-provided minimum wait before the next
+	// attempt, parsed from Retry-After / retry-after-ms / rate-limit reset
+	// headers. Zero means "no server hint — use computed backoff".
+	RetryAfter time.Duration
+	// StatusCode is the HTTP status of an API error, or 0 when the error did
+	// not originate from an HTTP response.
+	StatusCode int
 }
 
 // LoggableFields returns a slice of interface{} containing error information

--- a/llm/errors.go
+++ b/llm/errors.go
@@ -63,13 +63,25 @@ type LLMError struct {
 }
 
 // LoggableFields returns a slice of interface{} containing error information
-// in a format suitable for structured logging.
+// in a format suitable for structured logging. The classification fields
+// (status_code, retryable, retry_after) are appended only when meaningful, so
+// non-HTTP errors do not emit noisy zero-values.
 func (e *LLMError) LoggableFields() []interface{} {
-	return []interface{}{
+	fields := []interface{}{
 		"error_type", e.TypeString(),
 		"message", e.Message,
 		"error", e.Err,
 	}
+	if e.StatusCode != 0 {
+		fields = append(fields, "status_code", e.StatusCode)
+	}
+	if e.Retryable {
+		fields = append(fields, "retryable", e.Retryable)
+	}
+	if e.RetryAfter > 0 {
+		fields = append(fields, "retry_after", e.RetryAfter.String())
+	}
+	return fields
 }
 
 // Error implements the error interface.

--- a/llm/llm.go
+++ b/llm/llm.go
@@ -64,14 +64,15 @@ type LLM interface {
 // LLMImpl implements the LLM interface and manages interactions with specific providers.
 // It handles provider communication, error management, and logging.
 type LLMImpl struct {
-	Provider     providers.Provider     // The underlying LLM provider
-	Options      map[string]interface{} // Provider-specific options
-	optionsMutex sync.RWMutex           // Mutex to protect concurrent access to Options map
-	client       *http.Client           // HTTP client for API requests
-	logger       utils.Logger           // Logger for debugging and monitoring
-	config       *config.Config         // Configuration settings
-	MaxRetries   int                    // Maximum number of retry attempts
-	RetryDelay   time.Duration          // Delay between retry attempts
+	Provider      providers.Provider     // The underlying LLM provider
+	Options       map[string]interface{} // Provider-specific options
+	optionsMutex  sync.RWMutex           // Mutex to protect concurrent access to Options map
+	client        *http.Client           // HTTP client for API requests
+	logger        utils.Logger           // Logger for debugging and monitoring
+	config        *config.Config         // Configuration settings
+	MaxRetries    int                    // Maximum number of retry attempts
+	RetryDelay    time.Duration          // Base delay for exponential retry backoff
+	MaxRetryDelay time.Duration          // Cap on backoff growth (0 = uncapped)
 }
 
 // GenerateOption is a function type for configuring generation behavior.
@@ -111,13 +112,14 @@ func NewLLM(cfg *config.Config, logger utils.Logger, registry *providers.Provide
 	provider.SetDefaultOptions(cfg)
 
 	llmClient := &LLMImpl{
-		Provider:   provider,
-		client:     &http.Client{Timeout: cfg.Timeout},
-		logger:     logger,
-		config:     cfg,
-		MaxRetries: cfg.MaxRetries,
-		RetryDelay: cfg.RetryDelay,
-		Options:    make(map[string]interface{}),
+		Provider:      provider,
+		client:        &http.Client{Timeout: cfg.Timeout},
+		logger:        logger,
+		config:        cfg,
+		MaxRetries:    cfg.MaxRetries,
+		RetryDelay:    cfg.RetryDelay,
+		MaxRetryDelay: cfg.MaxRetryDelay,
+		Options:       make(map[string]interface{}),
 	}
 
 	return llmClient, nil
@@ -179,6 +181,7 @@ func (l *LLMImpl) Generate(ctx context.Context, prompt *Prompt, opts ...Generate
 	if prompt.SystemPrompt != "" {
 		l.SetOption("system_prompt", prompt.SystemPrompt)
 	}
+	var lastErr error
 	for attempt := 0; attempt <= l.MaxRetries; attempt++ {
 		l.logger.Debug("Generating text", "provider", l.Provider.Name(), "prompt", prompt.String(), "system_prompt", prompt.SystemPrompt, "attempt", attempt+1)
 		// Pass the entire Prompt struct to attemptGenerate
@@ -186,26 +189,19 @@ func (l *LLMImpl) Generate(ctx context.Context, prompt *Prompt, opts ...Generate
 		if err == nil {
 			return result, nil
 		}
-		l.logger.Warn("Generation attempt failed", "error", err, "attempt", attempt+1)
-		if attempt < l.MaxRetries {
-			l.logger.Debug("Retrying", "delay", l.RetryDelay)
-			if err := l.wait(ctx); err != nil {
-				return "", err
-			}
+		lastErr = err
+
+		proceed, ctxErr := l.shouldRetry(ctx, attempt, err)
+		if ctxErr != nil {
+			return "", ctxErr
+		}
+		if !proceed {
+			break
 		}
 	}
-	return "", fmt.Errorf("failed to generate after %d attempts", l.MaxRetries+1)
-}
-
-// wait implements a cancellable delay between retry attempts.
-// Returns context.Canceled if the context is cancelled during the wait.
-func (l *LLMImpl) wait(ctx context.Context) error {
-	select {
-	case <-ctx.Done():
-		return ctx.Err()
-	case <-time.After(l.RetryDelay):
-		return nil
-	}
+	// Surface the underlying error rather than masking it with an attempt
+	// count — callers classify on the typed error to decide what to do next.
+	return "", lastErr
 }
 
 // attemptGenerate makes a single attempt to generate text using the provider.
@@ -292,7 +288,7 @@ func (l *LLMImpl) attemptGenerate(ctx context.Context, prompt *Prompt) (string, 
 	}
 	resp, err := l.client.Do(req)
 	if err != nil {
-		return "", NewLLMError(ErrorTypeRequest, "failed to send request", err)
+		return "", classifyNetworkError(err)
 	}
 	defer resp.Body.Close()
 	body, err := io.ReadAll(resp.Body)
@@ -304,8 +300,14 @@ func (l *LLMImpl) attemptGenerate(ctx context.Context, prompt *Prompt) (string, 
 	l.logger.Debug("Full API response", "body", string(body))
 
 	if resp.StatusCode != http.StatusOK {
-		l.logger.Error("API error", "provider", l.Provider.Name(), "status", resp.StatusCode, "body", string(body))
-		return "", NewLLMError(ErrorTypeAPI, fmt.Sprintf("API error: status code %d", resp.StatusCode), nil)
+		apiErr := classifyAPIError(resp.StatusCode, resp.Header, body)
+		if apiErr.Retryable {
+			// Transient — log quietly so a batch of retries does not flood.
+			l.logger.Debug("Retryable API error", "provider", l.Provider.Name(), "status", resp.StatusCode, "retry_after", apiErr.RetryAfter.String())
+		} else {
+			l.logger.Error("API error", "provider", l.Provider.Name(), "status", resp.StatusCode, "body", string(body))
+		}
+		return "", apiErr
 	}
 
 	// Extract and log caching information

--- a/llm/retry.go
+++ b/llm/retry.go
@@ -1,0 +1,218 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/rand"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// classifyAPIError builds an LLMError for a non-2xx HTTP response, annotating
+// it with retryability and any server-provided Retry-After delay. The
+// classification mirrors the official Anthropic and OpenAI SDKs:
+//
+//   - 408, 409, 5xx (including Anthropic's 529 overloaded): retryable-transient.
+//   - 429: rate-limited and retryable, honoring the server's wait hint, unless
+//     the body reports OpenAI's insufficient_quota (out of credits) which is
+//     permanent.
+//   - any other 4xx: permanent.
+func classifyAPIError(statusCode int, header http.Header, body []byte) *LLMError {
+	le := &LLMError{
+		Type:       ErrorTypeAPI,
+		Message:    fmt.Sprintf("API error: status code %d", statusCode),
+		StatusCode: statusCode,
+		RetryAfter: parseRetryAfter(header),
+	}
+
+	switch {
+	case statusCode == http.StatusTooManyRequests: // 429
+		le.Type = ErrorTypeRateLimit
+		// insufficient_quota is a 429 that means the account is out of
+		// credits — retrying never recovers it.
+		if errType, errCode := parseProviderError(body); errType == "insufficient_quota" || errCode == "insufficient_quota" {
+			le.Message = "API error: insufficient quota"
+			le.Retryable = false
+		} else {
+			le.Retryable = true
+		}
+	case statusCode == http.StatusRequestTimeout, // 408
+		statusCode == http.StatusConflict, // 409
+		statusCode >= 500:                 // 5xx incl. Anthropic 529
+		le.Retryable = true
+	default:
+		le.Retryable = false
+	}
+
+	return le
+}
+
+// classifyNetworkError wraps a transport-level failure from http.Client.Do.
+// Genuine network errors (connection reset, DNS, refused) are retryable;
+// context cancellation and deadline expiry are not — the deadline is shared
+// across attempts, so retrying cannot beat it.
+func classifyNetworkError(err error) *LLMError {
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return &LLMError{Type: ErrorTypeRequest, Message: "request cancelled", Err: err, Retryable: false}
+	}
+	return &LLMError{Type: ErrorTypeRequest, Message: "failed to send request", Err: err, Retryable: true}
+}
+
+// parseProviderError reads the provider error envelope to extract the typed
+// error string. It tolerates both the Anthropic shape ({"error":{"type":...}})
+// and the OpenAI shape ({"error":{"type":...,"code":...}}). Missing or
+// unparseable bodies yield empty strings.
+func parseProviderError(body []byte) (errType, errCode string) {
+	if len(body) == 0 {
+		return "", ""
+	}
+	var env struct {
+		Error struct {
+			Type string `json:"type"`
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		return "", ""
+	}
+	return env.Error.Type, env.Error.Code
+}
+
+// parseRetryAfter extracts a server-provided wait hint from rate-limit
+// response headers, in priority order:
+//
+//  1. retry-after-ms — OpenAI's millisecond-precision hint.
+//  2. retry-after — integer seconds (Anthropic) or an HTTP-date.
+//  3. x-ratelimit-reset-{requests,tokens} — OpenAI duration strings ("6s",
+//     "1m30s") describing when a bucket refills; used only as a fallback.
+//
+// It returns 0 when no usable hint is present, leaving the caller to apply
+// computed backoff.
+func parseRetryAfter(h http.Header) time.Duration {
+	if h == nil {
+		return 0
+	}
+
+	if ms := strings.TrimSpace(h.Get("retry-after-ms")); ms != "" {
+		if v, err := strconv.Atoi(ms); err == nil && v >= 0 {
+			return time.Duration(v) * time.Millisecond
+		}
+	}
+
+	if ra := strings.TrimSpace(h.Get("retry-after")); ra != "" {
+		if secs, err := strconv.Atoi(ra); err == nil && secs >= 0 {
+			return time.Duration(secs) * time.Second
+		}
+		if t, err := http.ParseTime(ra); err == nil {
+			if d := time.Until(t); d > 0 {
+				return d
+			}
+			return 0
+		}
+	}
+
+	// Fallback: the soonest a constrained bucket says it will refill.
+	var reset time.Duration
+	for _, name := range []string{"x-ratelimit-reset-requests", "x-ratelimit-reset-tokens"} {
+		if d, ok := parseResetDuration(h.Get(name)); ok && d > reset {
+			reset = d
+		}
+	}
+	return reset
+}
+
+// parseResetDuration parses OpenAI's x-ratelimit-reset-* header values, which
+// are Go-style duration strings ("6s", "1m30s", "880ms") rather than epoch
+// seconds. It reports ok=false for empty, malformed, or negative values.
+func parseResetDuration(s string) (time.Duration, bool) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return 0, false
+	}
+	d, err := time.ParseDuration(s)
+	if err != nil || d < 0 {
+		return 0, false
+	}
+	return d, true
+}
+
+// retryDelay computes the wait before the next attempt: full jitter over an
+// exponential backoff (RetryDelay × 2^attempt, capped at MaxRetryDelay),
+// floored by any server-provided delay. attempt is zero-based.
+func (l *LLMImpl) retryDelay(attempt int, serverDelay time.Duration) time.Duration {
+	base := l.RetryDelay
+	if base <= 0 {
+		base = 2 * time.Second
+	}
+
+	backoff := base
+	for i := 0; i < attempt; i++ {
+		backoff *= 2
+		if l.MaxRetryDelay > 0 && backoff > l.MaxRetryDelay {
+			backoff = l.MaxRetryDelay
+			break
+		}
+	}
+	if l.MaxRetryDelay > 0 && backoff > l.MaxRetryDelay {
+		backoff = l.MaxRetryDelay
+	}
+
+	// Full jitter: a uniformly random point in [0, backoff].
+	jittered := backoff
+	if backoff > 0 {
+		jittered = time.Duration(rand.Int63n(int64(backoff) + 1))
+	}
+
+	// An explicit server hint is authoritative as a floor.
+	if serverDelay > jittered {
+		return serverDelay
+	}
+	return jittered
+}
+
+// shouldRetry decides, after a failed attempt, whether the loop should make
+// another one and how long to wait first. It returns proceed=false when the
+// error is non-retryable or attempts are exhausted. When proceed is true it
+// has already waited (honoring context cancellation); a non-nil error means
+// the context was cancelled during the wait.
+func (l *LLMImpl) shouldRetry(ctx context.Context, attempt int, err error) (proceed bool, ctxErr error) {
+	if attempt >= l.MaxRetries {
+		return false, nil
+	}
+	var le *LLMError
+	if !errors.As(err, &le) || !le.Retryable {
+		return false, nil
+	}
+
+	delay := l.retryDelay(attempt, le.RetryAfter)
+	l.logger.Debug("Retrying generation", "attempt", attempt+1, "delay", delay.String(), "error", err)
+	if werr := l.waitFor(ctx, delay); werr != nil {
+		return false, werr
+	}
+	return true, nil
+}
+
+// waitFor sleeps for d, returning early with the context error if the context
+// is cancelled. A non-positive d still observes an already-cancelled context.
+func (l *LLMImpl) waitFor(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			return nil
+		}
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.C:
+		return nil
+	}
+}

--- a/llm/retry.go
+++ b/llm/retry.go
@@ -149,16 +149,19 @@ func (l *LLMImpl) retryDelay(attempt int, serverDelay time.Duration) time.Durati
 		base = 2 * time.Second
 	}
 
+	// Cap the base first so attempt 0 honors MaxRetryDelay even when base
+	// alone exceeds it; the in-loop cap then both clamps growth and prevents
+	// the doubling from overflowing int64 at high attempt counts.
 	backoff := base
+	if l.MaxRetryDelay > 0 && backoff > l.MaxRetryDelay {
+		backoff = l.MaxRetryDelay
+	}
 	for i := 0; i < attempt; i++ {
 		backoff *= 2
 		if l.MaxRetryDelay > 0 && backoff > l.MaxRetryDelay {
 			backoff = l.MaxRetryDelay
 			break
 		}
-	}
-	if l.MaxRetryDelay > 0 && backoff > l.MaxRetryDelay {
-		backoff = l.MaxRetryDelay
 	}
 
 	// Full jitter: a uniformly random point in [0, backoff].

--- a/llm/retry_test.go
+++ b/llm/retry_test.go
@@ -1,0 +1,261 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/teilomillet/gollm/providers"
+	"github.com/teilomillet/gollm/utils"
+)
+
+func TestParseResetDuration(t *testing.T) {
+	cases := []struct {
+		in   string
+		want time.Duration
+		ok   bool
+	}{
+		{"6s", 6 * time.Second, true},
+		{"1m30s", 90 * time.Second, true},
+		{"880ms", 880 * time.Millisecond, true},
+		{" 2s ", 2 * time.Second, true},
+		{"", 0, false},
+		{"soon", 0, false},
+		{"-3s", 0, false},
+	}
+	for _, c := range cases {
+		got, ok := parseResetDuration(c.in)
+		if ok != c.ok || got != c.want {
+			t.Errorf("parseResetDuration(%q) = (%v, %v), want (%v, %v)", c.in, got, ok, c.want, c.ok)
+		}
+	}
+}
+
+func TestParseRetryAfter(t *testing.T) {
+	cases := []struct {
+		name string
+		hdr  map[string]string
+		want time.Duration
+	}{
+		{"openai retry-after-ms wins", map[string]string{"retry-after-ms": "1500", "retry-after": "9"}, 1500 * time.Millisecond},
+		{"anthropic retry-after seconds", map[string]string{"retry-after": "12"}, 12 * time.Second},
+		{"reset fallback takes the larger", map[string]string{"x-ratelimit-reset-requests": "2s", "x-ratelimit-reset-tokens": "5s"}, 5 * time.Second},
+		{"explicit beats reset", map[string]string{"retry-after": "1", "x-ratelimit-reset-tokens": "30s"}, 1 * time.Second},
+		{"nothing usable", map[string]string{}, 0},
+		{"garbage ignored", map[string]string{"retry-after": "later"}, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			h := http.Header{}
+			for k, v := range c.hdr {
+				h.Set(k, v)
+			}
+			if got := parseRetryAfter(h); got != c.want {
+				t.Errorf("parseRetryAfter(%v) = %v, want %v", c.hdr, got, c.want)
+			}
+		})
+	}
+
+	if got := parseRetryAfter(nil); got != 0 {
+		t.Errorf("parseRetryAfter(nil) = %v, want 0", got)
+	}
+}
+
+func TestParseProviderError(t *testing.T) {
+	cases := []struct {
+		name     string
+		body     string
+		wantType string
+		wantCode string
+	}{
+		{"anthropic rate limit", `{"type":"error","error":{"type":"rate_limit_error","message":"slow down"}}`, "rate_limit_error", ""},
+		{"openai insufficient quota", `{"error":{"message":"You exceeded your quota","type":"insufficient_quota","code":"insufficient_quota"}}`, "insufficient_quota", "insufficient_quota"},
+		{"empty body", ``, "", ""},
+		{"non-json body", `Bad Gateway`, "", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			gotType, gotCode := parseProviderError([]byte(c.body))
+			if gotType != c.wantType || gotCode != c.wantCode {
+				t.Errorf("parseProviderError(%q) = (%q, %q), want (%q, %q)", c.body, gotType, gotCode, c.wantType, c.wantCode)
+			}
+		})
+	}
+}
+
+func TestClassifyAPIError(t *testing.T) {
+	cases := []struct {
+		name          string
+		status        int
+		body          string
+		wantRetryable bool
+		wantType      ErrorType
+	}{
+		{"429 rate limit", 429, `{"error":{"type":"rate_limit_error"}}`, true, ErrorTypeRateLimit},
+		{"429 insufficient quota", 429, `{"error":{"type":"insufficient_quota","code":"insufficient_quota"}}`, false, ErrorTypeRateLimit},
+		{"408 timeout", 408, ``, true, ErrorTypeAPI},
+		{"409 conflict", 409, ``, true, ErrorTypeAPI},
+		{"500 server error", 500, ``, true, ErrorTypeAPI},
+		{"529 anthropic overloaded", 529, ``, true, ErrorTypeAPI},
+		{"400 bad request", 400, ``, false, ErrorTypeAPI},
+		{"401 unauthorized", 401, ``, false, ErrorTypeAPI},
+		{"404 not found", 404, ``, false, ErrorTypeAPI},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			le := classifyAPIError(c.status, http.Header{}, []byte(c.body))
+			if le.Retryable != c.wantRetryable {
+				t.Errorf("status %d: Retryable = %v, want %v", c.status, le.Retryable, c.wantRetryable)
+			}
+			if le.Type != c.wantType {
+				t.Errorf("status %d: Type = %v, want %v", c.status, le.Type, c.wantType)
+			}
+			if le.StatusCode != c.status {
+				t.Errorf("status %d: StatusCode = %v, want %v", c.status, le.StatusCode, c.status)
+			}
+		})
+	}
+}
+
+func TestClassifyNetworkError(t *testing.T) {
+	if le := classifyNetworkError(errors.New("connection reset by peer")); !le.Retryable {
+		t.Error("generic network error should be retryable")
+	}
+	if le := classifyNetworkError(context.Canceled); le.Retryable {
+		t.Error("context.Canceled must not be retryable")
+	}
+	if le := classifyNetworkError(context.DeadlineExceeded); le.Retryable {
+		t.Error("context.DeadlineExceeded must not be retryable")
+	}
+}
+
+func TestRetryDelay(t *testing.T) {
+	l := &LLMImpl{RetryDelay: 2 * time.Second, MaxRetryDelay: 10 * time.Second}
+
+	// Backoff upper bound grows as base*2^attempt, capped at MaxRetryDelay.
+	// Full jitter keeps each sample within [0, bound].
+	bounds := map[int]time.Duration{0: 2 * time.Second, 1: 4 * time.Second, 2: 8 * time.Second, 3: 10 * time.Second, 4: 10 * time.Second}
+	for attempt, bound := range bounds {
+		for i := 0; i < 200; i++ {
+			got := l.retryDelay(attempt, 0)
+			if got < 0 || got > bound {
+				t.Fatalf("retryDelay(%d) = %v, want within [0, %v]", attempt, got, bound)
+			}
+		}
+	}
+
+	// A server-provided delay is an authoritative floor, even past the cap.
+	if got := l.retryDelay(0, 30*time.Second); got != 30*time.Second {
+		t.Errorf("server floor: retryDelay(0, 30s) = %v, want 30s", got)
+	}
+}
+
+// --- loop integration: transient retries, permanent fails fast ---
+
+// stubProvider implements just the methods attemptGenerate calls; the embedded
+// interface satisfies the rest (and panics loudly if anything else is hit).
+type stubProvider struct {
+	providers.Provider
+}
+
+func (stubProvider) Name() string               { return "stub" }
+func (stubProvider) Endpoint() string           { return "http://stub.local/v1/generate" }
+func (stubProvider) Headers() map[string]string { return map[string]string{} }
+func (stubProvider) PrepareRequest(string, map[string]interface{}) ([]byte, error) {
+	return []byte(`{}`), nil
+}
+func (stubProvider) ParseResponse(body []byte) (string, error) { return string(body), nil }
+
+// scriptedRT returns canned responses/errors in sequence and records call count.
+type scriptedRT struct {
+	steps []func() (*http.Response, error)
+	calls int
+}
+
+func (s *scriptedRT) RoundTrip(*http.Request) (*http.Response, error) {
+	i := s.calls
+	s.calls++
+	if i >= len(s.steps) {
+		return nil, errors.New("scriptedRT: unexpected extra call")
+	}
+	return s.steps[i]()
+}
+
+func resp(status int, body string) func() (*http.Response, error) {
+	return func() (*http.Response, error) {
+		return &http.Response{
+			StatusCode: status,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader(body)),
+		}, nil
+	}
+}
+
+func newTestLLM(rt http.RoundTripper) *LLMImpl {
+	return &LLMImpl{
+		Provider:      stubProvider{},
+		client:        &http.Client{Transport: rt},
+		logger:        utils.NewLogger(utils.LogLevelOff),
+		Options:       make(map[string]interface{}),
+		MaxRetries:    4,
+		RetryDelay:    time.Millisecond,
+		MaxRetryDelay: 5 * time.Millisecond,
+	}
+}
+
+func TestGenerateRetriesTransientThenSucceeds(t *testing.T) {
+	rt := &scriptedRT{steps: []func() (*http.Response, error){
+		func() (*http.Response, error) { return nil, errors.New("connection reset by peer") },
+		resp(503, `boom`),
+		resp(200, `ok`),
+	}}
+	l := newTestLLM(rt)
+
+	got, err := l.Generate(context.Background(), &Prompt{Input: "hi"})
+	if err != nil {
+		t.Fatalf("expected success after retries, got %v", err)
+	}
+	if got != "ok" {
+		t.Errorf("result = %q, want %q", got, "ok")
+	}
+	if rt.calls != 3 {
+		t.Errorf("calls = %d, want 3", rt.calls)
+	}
+}
+
+func TestGeneratePermanentFailsFast(t *testing.T) {
+	rt := &scriptedRT{steps: []func() (*http.Response, error){
+		resp(400, `{"error":{"type":"invalid_request_error"}}`),
+	}}
+	l := newTestLLM(rt)
+
+	_, err := l.Generate(context.Background(), &Prompt{Input: "hi"})
+	if err == nil {
+		t.Fatal("expected permanent error, got nil")
+	}
+	var le *LLMError
+	if !errors.As(err, &le) || le.StatusCode != 400 {
+		t.Errorf("want underlying 400 LLMError, got %v", err)
+	}
+	if rt.calls != 1 {
+		t.Errorf("calls = %d, want 1 (no retry on permanent)", rt.calls)
+	}
+}
+
+func TestGenerateInsufficientQuotaFailsFast(t *testing.T) {
+	rt := &scriptedRT{steps: []func() (*http.Response, error){
+		resp(429, `{"error":{"type":"insufficient_quota","code":"insufficient_quota"}}`),
+	}}
+	l := newTestLLM(rt)
+
+	if _, err := l.Generate(context.Background(), &Prompt{Input: "hi"}); err == nil {
+		t.Fatal("expected insufficient_quota to fail without retry")
+	}
+	if rt.calls != 1 {
+		t.Errorf("calls = %d, want 1 (insufficient_quota is permanent)", rt.calls)
+	}
+}

--- a/llm/retry_test.go
+++ b/llm/retry_test.go
@@ -152,6 +152,27 @@ func TestRetryDelay(t *testing.T) {
 	if got := l.retryDelay(0, 30*time.Second); got != 30*time.Second {
 		t.Errorf("server floor: retryDelay(0, 30s) = %v, want 30s", got)
 	}
+
+	// Default config (the common caller path): RetryDelay <= 0 falls back to a
+	// 2s base, and MaxRetryDelay == 0 leaves backoff uncapped — so the bound
+	// grows as 2s*2^attempt with no ceiling.
+	t.Run("default config", func(t *testing.T) {
+		def := &LLMImpl{}
+		bounds := map[int]time.Duration{
+			0: 2 * time.Second,
+			1: 4 * time.Second,
+			2: 8 * time.Second,
+			3: 16 * time.Second,
+			4: 32 * time.Second,
+		}
+		for attempt, bound := range bounds {
+			for i := 0; i < 200; i++ {
+				if got := def.retryDelay(attempt, 0); got < 0 || got > bound {
+					t.Fatalf("default retryDelay(%d) = %v, want within [0, %v]", attempt, got, bound)
+				}
+			}
+		}
+	})
 }
 
 // --- loop integration: transient retries, permanent fails fast ---
@@ -257,5 +278,79 @@ func TestGenerateInsufficientQuotaFailsFast(t *testing.T) {
 	}
 	if rt.calls != 1 {
 		t.Errorf("calls = %d, want 1 (insufficient_quota is permanent)", rt.calls)
+	}
+}
+
+func TestGenerateRetriesRateLimitHonorsRetryAfter(t *testing.T) {
+	rt := &scriptedRT{steps: []func() (*http.Response, error){
+		func() (*http.Response, error) {
+			h := http.Header{}
+			h.Set("retry-after-ms", "60")
+			return &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+				Header:     h,
+				Body:       io.NopCloser(strings.NewReader(`{"error":{"type":"rate_limit_error"}}`)),
+			}, nil
+		},
+		resp(200, `ok`),
+	}}
+	l := newTestLLM(rt)
+	// Tiny base backoff so the server-provided 60ms Retry-After dominates.
+	l.RetryDelay = time.Millisecond
+	l.MaxRetryDelay = 10 * time.Second
+
+	start := time.Now()
+	got, err := l.Generate(context.Background(), &Prompt{Input: "hi"})
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("expected success after rate-limit retry, got %v", err)
+	}
+	if got != "ok" {
+		t.Errorf("result = %q, want %q", got, "ok")
+	}
+	if rt.calls != 2 {
+		t.Errorf("calls = %d, want 2", rt.calls)
+	}
+	// The retry must have waited at least the header-derived 60ms, not the 1ms
+	// base backoff — proves the server hint is honored as the floor.
+	if elapsed < 60*time.Millisecond {
+		t.Errorf("elapsed %v, want >= 60ms (Retry-After honored over base backoff)", elapsed)
+	}
+}
+
+func TestWaitForCancellation(t *testing.T) {
+	l := &LLMImpl{}
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancelled before the wait begins
+
+	if err := l.waitFor(ctx, time.Hour); !errors.Is(err, context.Canceled) {
+		t.Errorf("waitFor(1h) on cancelled ctx = %v, want context.Canceled", err)
+	}
+	// The non-positive fast path still observes cancellation.
+	if err := l.waitFor(ctx, 0); !errors.Is(err, context.Canceled) {
+		t.Errorf("waitFor(0) on cancelled ctx = %v, want context.Canceled", err)
+	}
+}
+
+func TestGenerateStopsRetryingOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	rt := &scriptedRT{steps: []func() (*http.Response, error){
+		func() (*http.Response, error) {
+			cancel() // cancel after the first retryable failure, before the wait
+			return resp(503, `boom`)()
+		},
+		resp(200, `ok`), // must never be reached
+	}}
+	l := newTestLLM(rt)
+	// Long backoff: without cancellation the wait would block well past the test.
+	l.RetryDelay = time.Hour
+	l.MaxRetryDelay = time.Hour
+
+	_, err := l.Generate(ctx, &Prompt{Input: "hi"})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Generate = %v, want context.Canceled", err)
+	}
+	if rt.calls != 1 {
+		t.Errorf("calls = %d, want 1 (cancelled before retry)", rt.calls)
 	}
 }


### PR DESCRIPTION
The `Generate` path currently makes a single attempt and collapses every non-200 response into a generic `ErrorTypeAPI`, discarding the response headers. As a result transient failures (connection resets, 429 rate limits, 5xx) fail immediately, and a server's `Retry-After` is never honored.

This adds a classification + backoff layer:

- **`llm/retry.go`** — classifies HTTP and network errors as:
  - *retryable-transient*: connection/network errors, 408, 409, 5xx (including Anthropic's 529 overloaded);
  - *rate-limited*: 429, honoring `Retry-After` (seconds), OpenAI `retry-after-ms` (milliseconds), and `x-ratelimit-reset-*` duration strings as a fallback;
  - *permanent*: other 4xx, and OpenAI `insufficient_quota`.
- Full-jitter exponential backoff floored by any server-provided delay; bounded by `MaxRetries` and fully ctx-cancellable.
- New `MaxRetryDelay` config (`LLM_MAX_RETRY_DELAY`, default `60s`) caps backoff growth.
- `Generate` now returns the underlying error on exhaustion instead of masking it with `"failed after N attempts"`, so callers can classify the failure. Per-attempt retries log at Debug rather than Warn.

**Behavior change to note:** `RetryDelay` shifts meaning from a *fixed* inter-attempt delay to the *base* of the exponential backoff curve. Existing callers that set it get exponential growth (floored at the same value) instead of a flat wait.

**Scope:** `GenerateWithSchema` is intentionally left on its existing retry-on-any-error loop. Routing it through the same policy is a sensible follow-up, but doing so here would change its re-ask-on-malformed-output semantics, so it's deferred.

Tests are table-driven for the classifier, header parsing (including OpenAI `reset-*` durations and `insufficient_quota`), and delay/jitter bounds, plus loop tests covering transient-retry-then-success, permanent fail-fast, and `insufficient_quota` fail-fast.

## Summary by Sourcery

Introduce provider-aware retry and backoff handling for LLM generation requests, including classification of transient, rate-limit, and permanent errors.

Enhancements:
- Add configurable exponential backoff with jitter and optional maximum delay for LLM retries.
- Classify HTTP and network errors into retryable, rate-limited, and permanent categories, preserving status codes and retry hints on LLM errors.
- Change Generate to stop masking underlying errors on retry exhaustion so callers can inspect the original failure.
- Adjust logging so retryable errors are logged at debug level while permanent API errors remain error-level.

Tests:
- Add unit and integration-style tests covering error classification, retry-after header parsing, backoff bounds, and retry-loop behavior for transient and permanent failures.