### PR TITLE
fix(openai): send max_completion_tokens for gpt-5 models

### DIFF
--- a/providers/openai.go
+++ b/providers/openai.go
@@ -65,6 +65,12 @@ func (p *OpenAIProvider) needsMaxCompletionTokens() bool {
 		return true
 	}
 
+	// Check for gpt-5 and newer chat models, which require max_completion_tokens
+	// and reject max_tokens with HTTP 400 (e.g. gpt-5, gpt-5-mini, gpt-5.4-2026-03-05)
+	if strings.HasPrefix(p.model, "gpt-5") {
+		return true
+	}
+
 	return false
 }
 

--- a/providers/openai_test.go
+++ b/providers/openai_test.go
@@ -1,6 +1,7 @@
 package providers
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,6 +22,9 @@ func TestNeedsMaxCompletionTokens(t *testing.T) {
 		{"o-preview", true, "o-preview model should use max_completion_tokens"},
 		{"gpt-4o", true, "GPT-4o model should use max_completion_tokens"},
 		{"gpt-4o-mini", true, "GPT-4o mini model should use max_completion_tokens"},
+		{"gpt-5", true, "GPT-5 model should use max_completion_tokens"},
+		{"gpt-5-mini", true, "GPT-5 mini model should use max_completion_tokens"},
+		{"gpt-5.4-2026-03-05", true, "Dated GPT-5 model should use max_completion_tokens"},
 	}
 
 	for _, tc := range testCases {
@@ -37,4 +41,24 @@ func TestNeedsMaxCompletionTokens(t *testing.T) {
 			assert.Equal(t, tc.expectedResult, result, "needsMaxCompletionTokens returned unexpected result for model %s", tc.modelName)
 		})
 	}
+}
+
+// TestPrepareRequestGPT5UsesMaxCompletionTokens verifies that a gpt-5 request
+// carries max_completion_tokens and never max_tokens — the parameter gpt-5-class
+// models reject with HTTP 400.
+func TestPrepareRequestGPT5UsesMaxCompletionTokens(t *testing.T) {
+	provider, ok := NewOpenAIProvider("fake-api-key", "gpt-5.4-2026-03-05", nil).(*OpenAIProvider)
+	assert.True(t, ok, "Provider should be of type *OpenAIProvider")
+
+	body, err := provider.PrepareRequest("hello", map[string]interface{}{"max_tokens": 4096})
+	assert.NoError(t, err)
+
+	var req map[string]interface{}
+	assert.NoError(t, json.Unmarshal(body, &req))
+
+	_, hasMaxTokens := req["max_tokens"]
+	maxCompletion, hasMaxCompletion := req["max_completion_tokens"]
+	assert.False(t, hasMaxTokens, "gpt-5 request must not send max_tokens (OpenAI rejects it with HTTP 400)")
+	assert.True(t, hasMaxCompletion, "gpt-5 request must send max_completion_tokens instead")
+	assert.Equal(t, float64(4096), maxCompletion, "token budget must be preserved across the conversion")
 }


### PR DESCRIPTION
## Problem

gpt-5-class models reject the `max_tokens` parameter with HTTP 400 — they require `max_completion_tokens` instead. Any caller that sets a token budget against a gpt-5 model (e.g. `gpt-5`, `gpt-5-mini`, `gpt-5.4-2026-03-05`) currently gets a 400.

## Fix

`needsMaxCompletionTokens()` already recognizes the o-series and `4o` models that need `max_completion_tokens`; this extends it to `gpt-5*`. Both `SetOption` and the `PrepareRequest` variants route through that single predicate, so every request path is covered by the one change.

## Tests

- Detection table cases for `gpt-5`, `gpt-5-mini`, and `gpt-5.4-2026-03-05`.
- A `PrepareRequest` test asserting a gpt-5 request body carries `max_completion_tokens` and never `max_tokens`, with the token budget preserved across the conversion.

## Summary by Sourcery

Ensure OpenAI provider uses max_completion_tokens for gpt-5-class models instead of max_tokens to avoid API errors.

Tests:
- Add detection cases confirming gpt-5 variants require max_completion_tokens.
- Add a PrepareRequest test verifying gpt-5 requests send max_completion_tokens, never max_tokens, while preserving the token budget.